### PR TITLE
Fix uclibc DNS search paths

### DIFF
--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
 		rsync \
 		unzip \
 		wget \
+		git \
 	&& rm -rf /var/lib/apt/lists/*
 
 # we grab buildroot for it's uClibc toolchain
@@ -65,6 +66,10 @@ RUN yConfs=' \
 	&& for conf in $yConfs; do \
 		grep -q "^$conf=y" .config; \
 	done
+
+COPY resolv.c.patch /usr/src/buildroot/package/uclibc/1.0.9/0001-resolv-retry-error.patch
+
+ENV TERM xterm
 
 # http://www.finnie.org/2014/02/13/compiling-busybox-with-uclibc/
 RUN make -C /usr/src/buildroot -j$(nproc) toolchain

--- a/uclibc/resolv.c.patch
+++ b/uclibc/resolv.c.patch
@@ -1,0 +1,20 @@
+diff --git a/libc/inet/resolv.c b/libc/inet/resolv.c
+index 4b33896..a6cc00e 100644
+--- a/libc/inet/resolv.c
++++ b/libc/inet/resolv.c
+@@ -1320,7 +1320,6 @@ int __dns_lookup(const char *name,
+ 				local_ns_num = last_ns_num;
+ 			retries_left = __nameservers * __resolv_attempts;
+ 		}
+-		retries_left--;
+ 		if (local_ns_num >= __nameservers)
+ 			local_ns_num = 0;
+ 		local_id++;
+@@ -1572,6 +1571,7 @@ int __dns_lookup(const char *name,
+ 
+  try_next_server:
+ 		/* Try next nameserver */
++               retries_left--;
+ 		local_ns_num++;
+ 		variant = -1;
+ 	} while (retries_left > 0);


### PR DESCRIPTION
Fixes #9 

This PR contains the patch created by @thockin: http://mailman.uclibc-ng.org/pipermail/devel/2016-February/000775.html

```
$ docker run --dns-search=f1 --dns-search=f2 --dns-search=f3 --dns-search=f4 --dns-search=f5 --dns-search=f6 --dns-search=f7 --dns-search=f8 --dns-search=f9 --dns-search=google.com  busybox:uclibc nslookup www
Server:    8.8.8.8
Address 1: 8.8.8.8 google-public-dns-a.google.com

Name:      www
Address 1: 2800:3f0:4003:c01::63
Address 2: 190.45.0.39 pc-39-0-45-190.cm.vtr.net
Address 3: 190.45.0.30 pc-30-0-45-190.cm.vtr.net
Address 4: 190.45.0.20 pc-20-0-45-190.cm.vtr.net
Address 5: 190.45.0.24 pc-24-0-45-190.cm.vtr.net
Address 6: 190.45.0.29 pc-29-0-45-190.cm.vtr.net
Address 7: 190.45.0.35 pc-35-0-45-190.cm.vtr.net
Address 8: 190.45.0.44 pc-44-0-45-190.cm.vtr.net
Address 9: 190.45.0.54 pc-54-0-45-190.cm.vtr.net
Address 10: 190.45.0.50 pc-50-0-45-190.cm.vtr.net
Address 11: 190.45.0.34 pc-34-0-45-190.cm.vtr.net
Address 12: 190.45.0.25 pc-25-0-45-190.cm.vtr.net
Address 13: 190.45.0.45 pc-45-0-45-190.cm.vtr.net
Address 14: 190.45.0.59 pc-59-0-45-190.cm.vtr.net
Address 15: 190.45.0.40 pc-40-0-45-190.cm.vtr.net
Address 16: 190.45.0.55 pc-55-0-45-190.cm.vtr.net
Address 17: 190.45.0.49 pc-49-0-45-190.cm.vtr.net
```