### PR TITLE
Set an explicit version of uClibc-ng, and bump it to the latest 1.0.13 release

### DIFF
--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -66,6 +66,15 @@ RUN yConfs=' \
 		grep -q "^$conf=y" .config; \
 	done
 
+ENV UCLIBC_NG_VERSION 1.0.13
+ENV UCLIBC_NG_SHA256 7baae61e243da3ab85e219fead68406995be5eabf889001c0d41676546b19317
+
+RUN set -xe \
+	&& cd /usr/src/buildroot \
+	&& sed -i 's!^BR2_UCLIBC_VERSION_STRING=.*!BR2_UCLIBC_VERSION_STRING="'"$UCLIBC_NG_VERSION"'"!' .config \
+	&& grep -q '^BR2_UCLIBC_VERSION_STRING="'"$UCLIBC_NG_VERSION"'"$' .config \
+	&& echo "sha256  $UCLIBC_NG_SHA256  uClibc-ng-${UCLIBC_NG_VERSION}.tar.xz" > package/uclibc/uclibc.hash
+
 # http://www.finnie.org/2014/02/13/compiling-busybox-with-uclibc/
 RUN make -C /usr/src/buildroot -j$(nproc) toolchain
 ENV PATH /usr/src/buildroot/output/host/usr/bin:$PATH


### PR DESCRIPTION
Fixes #9
Closes #10

The patches in question were merged upstream (http://www.uclibc-ng.org/changeset/2ac8348609b63d6f3a87cb27ce17deff889c6a73/uclibc-ng and http://www.uclibc-ng.org/changeset/8c85b44f6ab42561207365f19b9d1fd69d960771/uclibc-ng), and are included in this latest 1.0.13 release (from 2016-03-13; yesterday). :smile:

cc @thockin @aledbf (wanna give this a go? :+1:)