### PR TITLE
Fix #18 generate-stackbrew-library.sh version issue.

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -14,14 +14,13 @@ fileCommit() {
 	git log -1 --format='format:%H' --branches -- "$@"
 }
 
-# get the most recent commit which modified "$1/Dockerfile" or any file COPY'd from "$1/Dockerfile"
+# get the most recent commit which modified "$1"
 dirCommit() {
 	local dir="$1"; shift
 	(
-		cd "$dir"
-		dfCommit="$(fileCommit Dockerfile)"
+		dfCommit="$(fileCommit "$dir")"
 		fileCommit \
-			Dockerfile \
+			"$dir" \
 			$(git show "$dfCommit":./Dockerfile | awk '
 				toupper($1) ~ /^(COPY|ADD)$/ {
 					for (i = 2; i < NF; i++) {


### PR DESCRIPTION
The origin one will generate the result with wrong version which is
based on the last commit on "$1/Dockerfile" which is not correct:
($1 here stands for variant)
```
# this file is generated via https://github.com/docker-library/busybox/blob/e127beb6877e2c00f81112c74dea80fc3bcddcee/generate-stackbrew-library.sh

Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
             Jérôme Petazzoni <jerome@docker.com> (@jpetazzo)
GitRepo: https://github.com/docker-library/busybox.git
GitFetch: refs/heads/dist

Tags: 1.24.1-glibc, 1.24-glibc, 1-glibc, glibc
GitCommit: 6b303c84f063bea2bc3bc86dc86c4db1f3a8b5d3
Directory: glibc

Tags: 1.24.1-musl, 1.24-musl, 1-musl, musl
GitCommit: 6b303c84f063bea2bc3bc86dc86c4db1f3a8b5d3
Directory: musl

Tags: 1.24.1-uclibc, 1.24-uclibc, 1-uclibc, uclibc, 1.24.1, 1.24, 1, latest
GitCommit: 6b303c84f063bea2bc3bc86dc86c4db1f3a8b5d3
Directory: uclibc
```

Currently, the wrong version will always be v1.24.1 because it's the
version we last time changed "$1/Dockerfile", since we'll update version
inside "$1/Dockerfile.builder", so the better method here IMO is to get
the latest changing commit on "$1" but not "$1/Dockerfile".

Note:
This bug was born in commit 38b1f26b588d3ce56d0dc846c98c976e916a3e7f