### PR TITLE
Set clone depth=1 in CI to save resource and time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - VERSION=uclibc
 
 install:
-  - git clone https://github.com/docker-library/official-images.git ~/official-images
+  - git clone --depth 1 https://github.com/docker-library/official-images.git ~/official-images
 
 before_script:
   - env | sort


### PR DESCRIPTION
We don't need to clone the whole history of the git repo to do the things we're going to do, the latest one should be enough.