### PR TITLE
Fix Travis CI build failed due to the massive log

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ for version in "${versions[@]}"; do
 	[ -f "$version/Dockerfile.builder" ] || continue
 	(
 		set -x
-		docker build -t "$base$version-builder" --pull -f "$version/Dockerfile.builder" "$version"
+		docker build --build-arg=CI="${CI}" -t "$base$version-builder" --pull -f "$version/Dockerfile.builder" "$version"
 		docker run --rm "$base$version-builder" tar cC rootfs . | xz -z9 > "$version/busybox.tar.xz"
 		docker build -t "$base$version" "$version"
 		docker run --rm "$base$version" sh -xec 'true'

--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -1,5 +1,6 @@
 FROM debian:jessie
 
+ARG CI
 RUN apt-get update && apt-get install -y \
 		bzip2 \
 		curl \

--- a/musl/Dockerfile.builder
+++ b/musl/Dockerfile.builder
@@ -1,5 +1,6 @@
 FROM alpine:3.3
 
+ARG CI
 RUN apk add --no-cache \
 		bzip2 \
 		curl \

--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -1,5 +1,6 @@
 FROM debian:jessie
 
+ARG CI
 RUN apt-get update && apt-get install -y \
 		bzip2 \
 		curl \
@@ -93,7 +94,8 @@ RUN set -xe \
 	&& echo "sha256  $UCLIBC_NG_SHA256  uClibc-ng-${UCLIBC_NG_VERSION}.tar.xz" > package/uclibc/uclibc.hash
 
 # http://www.finnie.org/2014/02/13/compiling-busybox-with-uclibc/
-RUN make -C /usr/src/buildroot -j$(nproc) toolchain
+RUN if [ "${CI}" = "true" ]; then make -C /usr/src/buildroot -j$(nproc) toolchain > /dev/null; else make -C /usr/src/buildroot -j$(nproc) toolchain; fi
+
 ENV PATH /usr/src/buildroot/output/host/usr/bin:$PATH
 
 # pub   1024D/ACC9965B 2006-12-12


### PR DESCRIPTION
This will redirect buildroot build stdout log inside uclibc variant, currently, the whole log of that build is too huge, so that Travis CI will kill it:

```
The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over).                                          
                                                                                                                                                                             
The job has been terminated
```

This redirection in CI of stdout can prevent this situation.