### PR TITLE
Update "musl" variant to Alpine 3.6

### DIFF
--- a/musl/Dockerfile.builder
+++ b/musl/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN apk add --no-cache \
 		bzip2 \


### PR DESCRIPTION
Tail end of the `./build.sh musl` output:
```console
Step 16/16 : RUN cp -L /etc/resolv.conf rootfs/etc/ 	&& chroot rootfs /bin/sh -xec 'nslookup google.com' 	&& rm rootfs/etc/resolv.conf
 ---> Running in a9a77c9c2a8c
+ nslookup google.com
nslookup: can't resolve '(null)'

Name:      google.com
Address 1: 172.217.11.78 lax17s34-in-f14.1e100.net
Address 2: 2607:f8b0:4007:802::200e lax17s34-in-x0e.1e100.net
 ---> c56addf83f45
Removing intermediate container a9a77c9c2a8c
Successfully built c56addf83f45
+ docker run --rm busybox:musl-builder tar cC rootfs .
+ xz -z9
+ docker build -t busybox:musl musl
Sending build context to Docker daemon  627.2kB
Step 1/3 : FROM scratch
 --->
Step 2/3 : ADD busybox.tar.xz /
 ---> eb4c56119b47
Removing intermediate container 1fd05035d650
Step 3/3 : CMD sh
 ---> Running in e80b784dc4b4
 ---> 25d4fcb9c0c5
Removing intermediate container e80b784dc4b4
Successfully built 25d4fcb9c0c5
+ docker run --rm busybox:musl sh -xec true
+ true
+ docker run --rm busybox:musl ping -c 1 google.com
PING google.com (172.217.11.78): 56 data bytes
64 bytes from 172.217.11.78: seq=0 ttl=53 time=13.123 ms

--- google.com ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 13.123/13.123/13.123 ms
+ docker images busybox:musl
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
busybox             musl                25d4fcb9c0c5        7 seconds ago       1.32MB
```