### PR TITLE
Update glibc's builder to stretch

### DIFF
--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -1,9 +1,10 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 RUN apt-get update && apt-get install -y \
 		bzip2 \
 		curl \
 		gcc \
+		gnupg2 dirmngr \
 		make \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -144,7 +145,7 @@ RUN set -ex \
 RUN chroot rootfs /bin/sh -xec 'true'
 
 # ensure correct timezone (UTC)
-RUN ln -v /etc/localtime rootfs/etc/ \
+RUN ln -vL /etc/localtime rootfs/etc/ \
 	&& [ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too


### PR DESCRIPTION
Size comparison:

```console
$ docker images 'busybox:glibc*'
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
busybox             glibc-test          612b91ab525b        6 minutes ago       4.37MB
busybox             glibc               3aa1364bbd97        4 weeks ago         4.34MB
busybox             glibc-builder       267411c608af        6 minutes ago       211MB
```