### PR TITLE
Update uclibc's builder to stretch

### DIFF
--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -1,9 +1,10 @@
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 RUN apt-get update && apt-get install -y \
 		bzip2 \
 		curl \
 		gcc \
+		gnupg2 dirmngr \
 		make \
 		\
 # buildroot
@@ -268,7 +269,7 @@ RUN set -ex \
 RUN chroot rootfs /bin/sh -xec 'true'
 
 # ensure correct timezone (UTC)
-RUN ln -v /etc/localtime rootfs/etc/ \
+RUN ln -vL /etc/localtime rootfs/etc/ \
 	&& [ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too


### PR DESCRIPTION
Size comparison:

```console
$ docker images 'busybox:uclibc*'
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
busybox             uclibc-test         0eccf8eb8ac0        38 seconds ago      1.11MB
busybox             uclibc              c30178c5239f        4 weeks ago         1.11MB
busybox             uclibc-builder      a3cdccf65e96        48 seconds ago      2.73GB
```

(no difference, since the compiled bits should be identical given we pull everything important from buildroot, not the host image)