### PR TITLE
Swap from "gnupg2" to "gnupg"

### DIFF
--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
 		bzip2 \
 		curl \
 		gcc \
-		gnupg2 dirmngr \
+		gnupg dirmngr \
 		make \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
 		bzip2 \
 		curl \
 		gcc \
-		gnupg2 dirmngr \
+		gnupg dirmngr \
 		make \
 		\
 # buildroot


### PR DESCRIPTION
See https://github.com/docker-library/python/issues/236 for details.