### PR TITLE
Update the base image of busybox

### DIFF
--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM debian:stretch-slim
+FROM debian:jessie-slim
 
 RUN apt-get update && apt-get install -y \
 		bzip2 \


### PR DESCRIPTION
Update the base image from `debian:stretch-slim` to `debian:jessie-slim`.
This update will fix below errors:
1. Build issue with `debian:stretch-slim`:
> Step 3/14 : RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C9E9416F76E610DBD09D040F47B70C55ACC9965B
>  ---> Running in afffa8b694b4
> gpg: directory '/root/.gnupg' created
> gpg: keybox '/root/.gnupg/pubring.kbx' created
> gpg: keyserver receive failed: Cannot assign requested address
> The command '/bin/sh -c gpg --keyserver ha.pool.sks-keyservers.net --recv-keys C9E9416F76E610DBD09D040F47B70C55ACC9965B' returned a non-zero code: 2

2. Networking related issue
   Reported by https://github.com/moby/moby/issues/35963

Signed-off-by: Dennis Chen <dennis.chen@arm.com>