### PR TITLE
Make sure all the buildroot bits have appropriate upstream-supplied permissions

### DIFF
--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -240,6 +240,7 @@ RUN set -ex \
 	\
 	&& chroot rootfs /bin/busybox --install /bin
 
+# install a few extra files from buildroot (/etc/passwd, etc)
 RUN set -ex; \
 	mkdir -p rootfs/etc; \
 	for f in passwd shadow group; do \
@@ -247,14 +248,20 @@ RUN set -ex; \
 			"../buildroot/system/skeleton/etc/$f" \
 			"rootfs/etc/$f"; \
 	done; \
-# https://git.busybox.net/buildroot/tree/system/device_table.txt
-	chmod 755 /etc; \
-	chmod 600 /etc/shadow; \
-	chmod 644 /etc/passwd
-
-# create /tmp
-RUN mkdir -p rootfs/tmp \
-	&& chmod 1777 rootfs/tmp
+# set expected permissions, etc too (https://git.busybox.net/buildroot/tree/system/device_table.txt)
+	awk ' \
+		!/^#/ { \
+			if ($2 != "d" && $2 != "f") { \
+				printf "error: unknown type \"%s\" encountered in line %d: %s\n", $2, NR, $0 > "/dev/stderr"; \
+				exit 1; \
+			} \
+			sub(/^\/?/, "rootfs/", $1); \
+			if ($2 == "d") { \
+				printf "mkdir -p %s\n", $1; \
+			} \
+			printf "chmod %s %s\n", $3, $1; \
+		} \
+	' "../buildroot/system/device_table.txt" | bash -Eeuo pipefail -x
 
 # create missing home directories
 RUN set -ex \
@@ -266,6 +273,7 @@ RUN set -ex \
 		if [ ! -d "$home" ]; then \
 			mkdir -p "$home"; \
 			chown "$user" "$home"; \
+			chmod 755 "$home"; \
 		fi; \
 	done
 
@@ -273,8 +281,9 @@ RUN set -ex \
 RUN chroot rootfs /bin/sh -xec 'true'
 
 # ensure correct timezone (UTC)
-RUN ln -vL /etc/localtime rootfs/etc/ \
-	&& [ "$(chroot rootfs date +%Z)" = 'UTC' ]
+RUN set -ex; \
+	ln -vL /usr/share/zoneinfo/UTC rootfs/etc/localtime; \
+	[ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too
 RUN cp -L /etc/resolv.conf rootfs/etc/ \


### PR DESCRIPTION
This parses the buildroot "device_table.txt" directly to both ensure the directories it specifies exist, and to apply the permissions it expects on the files they deem sensitive enough to explicitly note and update in their scripts.