### PR TITLE
Add initial mips64le support in uclibc

### DIFF
--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -113,6 +113,17 @@ RUN set -eux; \
 			"; \
 			;; \
 			\
+		mips64el) \
+			setConfs="$setConfs \
+				BR2_mips64el=y \
+				BR2_mips_64r2=y \
+				BR2_MIPS_NABI64=y \
+			"; \
+			unsetConfs="$unsetConfs \
+				BR2_MIPS_SOFT_FLOAT \
+			" \
+			;; \
+			\
 # TODO ppc64el ? (needs BR2_TOOLCHAIN_BUILDROOT_UCLIBC support)
 			\
 # TODO s390x ? (needs BR2_TOOLCHAIN_BUILDROOT_UCLIBC support)


### PR DESCRIPTION
Closes #71 

This depends initially on https://github.com/debuerreotype/docker-debian-artifacts/issues/84 and ultimately on https://github.com/docker-library/official-images/issues/6709.

I've tested it successfully via QEMU emulation, but have not been able to test/verify it on real hardware yet.