### PR TITLE
added some more cleanup tweaks

### DIFF
--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 RUN set -eux; \
 	apt-get update; \
-	apt-get install -y \
+	apt-get -no-install-recommends install -y \
 		bzip2 \
 		curl \
 		gcc \

--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -9,7 +9,14 @@ RUN set -eux; \
 		gnupg dirmngr \
 		make \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get clean; \
+	rm -rf \
+		/var/lib/apt/lists/* \
+		/tmp/* \
+        	/var/tmp/* \
+        	/usr/share/man \
+        	/usr/share/doc \
+        	/usr/share/doc-base
 
 # pub   1024D/ACC9965B 2006-12-12
 #       Key fingerprint = C9E9 416F 76E6 10DB D09D  040F 47B7 0C55 ACC9 965B

--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -21,7 +21,14 @@ RUN set -eux; \
 		unzip \
 		wget \
 	; \
-	rm -rf /var/lib/apt/lists/*
+	apt-get clean; \
+	rm -rf \
+		/var/lib/apt/lists/* \
+		/tmp/* \
+       		/var/tmp/* \
+       		/usr/share/man \
+       		/usr/share/doc \
+        	/usr/share/doc-base
 
 # we grab buildroot for it's uClibc toolchain
 

--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -2,7 +2,7 @@ FROM debian:buster-slim
 
 RUN set -eux; \
 	apt-get update; \
-	apt-get install -y \
+	apt-get -no-install-recommends install -y \
 		bzip2 \
 		curl \
 		gcc \


### PR DESCRIPTION
More cleanup tweaks using 

1. apt-get clean 

2. rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

removing downloaded packages and packages list will free up some space ,

results in smaller image size.