### PR TITLE
Update Buildroot to 2020.02.2

### DIFF
--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -121,7 +121,7 @@ RUN set -eux; \
 
 # download a few extra files from buildroot (/etc/passwd, etc)
 RUN set -eux; \
-	buildrootVersion='2020.02.1'; \
+	buildrootVersion='2020.02.2'; \
 	mkdir -p rootfs/etc; \
 	for f in passwd shadow group; do \
 		curl -fL -o "rootfs/etc/$f" "https://git.busybox.net/buildroot/plain/system/skeleton/etc/$f?id=$buildrootVersion"; \

--- a/musl/Dockerfile.builder
+++ b/musl/Dockerfile.builder
@@ -105,7 +105,7 @@ RUN set -eux; \
 
 # download a few extra files from buildroot (/etc/passwd, etc)
 RUN set -eux; \
-	buildrootVersion='2020.02.1'; \
+	buildrootVersion='2020.02.2'; \
 	mkdir -p rootfs/etc; \
 	for f in passwd shadow group; do \
 		curl -fL -o "rootfs/etc/$f" "https://git.busybox.net/buildroot/plain/system/skeleton/etc/$f?id=$buildrootVersion"; \

--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -33,7 +33,7 @@ RUN gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys AB07D806D2CE7
 
 # https://buildroot.org/download.html
 # https://buildroot.org/downloads/?C=M;O=D
-ENV BUILDROOT_VERSION 2020.02.1
+ENV BUILDROOT_VERSION 2020.02.2
 
 RUN set -eux; \
 	tarball="buildroot-${BUILDROOT_VERSION}.tar.bz2"; \


### PR DESCRIPTION
This is a test to see if https://github.com/docker-library/busybox/pull/81 is sufficient for testing bumps like this via PRs again! :smile: