### PR TITLE
fix: override filetype

### DIFF
--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -174,4 +174,4 @@ RUN cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 
-# vim:ft=Dockerfile
+# vim:set ft=dockerfile:

--- a/glibc/Dockerfile.builder
+++ b/glibc/Dockerfile.builder
@@ -173,3 +173,5 @@ RUN set -eux; \
 RUN cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
+
+# vim:ft=Dockerfile

--- a/musl/Dockerfile.builder
+++ b/musl/Dockerfile.builder
@@ -158,4 +158,4 @@ RUN cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 
-# vim:ft=Dockerfile
+# vim:set ft=dockerfile:

--- a/musl/Dockerfile.builder
+++ b/musl/Dockerfile.builder
@@ -157,3 +157,5 @@ RUN set -eux; \
 RUN cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
+
+# vim:ft=Dockerfile

--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -311,4 +311,4 @@ RUN cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 
-# vim:ft=Dockerfile
+# vim:set ft=dockerfile:

--- a/uclibc/Dockerfile.builder
+++ b/uclibc/Dockerfile.builder
@@ -310,3 +310,5 @@ RUN set -eux; \
 RUN cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
+
+# vim:ft=Dockerfile


### PR DESCRIPTION
Adds vim modeline ft comments to .builder files, which are assumed
to be Ruby files by various programs. This has the added benefit
of overriding the language for https://github.com/github/linguist/
without needing to add a .gitattributes file.