### PR TITLE
Add Debian Unstable to the CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/docker-library/bashbrew.git -b master ~/bashbrew
           strategy="$(GENERATE_STACKBREW_LIBRARY='.github/workflows/fake-gsl.sh' ~/bashbrew/scripts/github-actions/generate.sh)"
-          strategy="$(jq -c '.matrix.include = [ .matrix.include[] | .runs.build = "./build.sh " + (.meta.entries[].directory | @sh) + "\n" + .runs.build ]' <<<"$strategy")"
+          strategy="$(.github/workflows/munge-build.sh -c <<<"$strategy")"
+          strategy="$(.github/workflows/munge-debian-unstable.sh -c <<<"$strategy")"
           jq . <<<"$strategy" # sanity check / debugging aid
           echo "::set-output name=strategy::$strategy"
 

--- a/.github/workflows/fake-gsl.sh
+++ b/.github/workflows/fake-gsl.sh
@@ -12,11 +12,12 @@ fi
 
 echo 'Maintainers: foo (@bar)'
 echo 'GitRepo: https://github.com/docker-library/busybox.git'
+commit="$(git log -1 --format='format:%H')"
+echo "GitCommit: $commit"
 
 for d; do
-	commit="$(git log -1 --format='format:%H' "$d/Dockerfile")"
 	echo
 	echo "Tags: ${d////-}"
 	echo "Directory: $d"
-	echo "GitCommit: $commit"
+	echo "File: Dockerfile.builder"
 done

--- a/.github/workflows/munge-build.sh
+++ b/.github/workflows/munge-build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+jq '
+	.matrix.include |= map(
+		.runs.build = "./build.sh " + (.meta.entries[].directory | @sh) + "\n" + (.runs.build | sub(" --file [^ ]+ "; " "))
+	)
+' "$@"

--- a/.github/workflows/munge-debian-unstable.sh
+++ b/.github/workflows/munge-debian-unstable.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+jq '
+	.matrix.include += [
+		.matrix.include[]
+		| select(.name | test(" [(].+[)]") | not) # ignore any existing munged builds
+		| select(.os | startswith("windows-") | not)
+		| select(.meta.froms | any(startswith("debian:")))
+		| .name += " (debian:unstable)"
+		| .runs.pull = ([
+			"# pull debian:unstable variants of base images for Debian Ports architectures",
+			"# https://github.com/docker-library/oi-janky-groovy/blob/0f8796a8aeedca90aba0a7e102f35ea172a23bb3/tianon/busybox/arch-pipeline.groovy#L68-L71",
+			(
+				.meta.froms[]
+				| (sub(":[^-]+"; ":unstable") | @sh) as $img
+				| (
+					"docker pull " + $img,
+					"docker tag " + $img + " " + @sh
+				)
+			)
+		] | join("\n"))
+	]
+' "$@"

--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -39,9 +39,10 @@ RUN set -eux; \
 		bc \
 		cpio \
 		dpkg-dev \
+		file \
 		g++ \
 		perl \
-		python \
+		python3 \
 		rsync \
 		unzip \
 		wget \

--- a/stable/uclibc/Dockerfile.builder
+++ b/stable/uclibc/Dockerfile.builder
@@ -26,9 +26,10 @@ RUN set -eux; \
 		bc \
 		cpio \
 		dpkg-dev \
+		file \
 		g++ \
 		perl \
-		python \
+		python3 \
 		rsync \
 		unzip \
 		wget \

--- a/unstable/uclibc/Dockerfile.builder
+++ b/unstable/uclibc/Dockerfile.builder
@@ -26,9 +26,10 @@ RUN set -eux; \
 		bc \
 		cpio \
 		dpkg-dev \
+		file \
 		g++ \
 		perl \
-		python \
+		python3 \
 		rsync \
 		unzip \
 		wget \


### PR DESCRIPTION
 (to verify that Debian Ports arches like riscv64 are likely to continue working)

See also https://github.com/docker-library/oi-janky-groovy/blob/0f8796a8aeedca90aba0a7e102f35ea172a23bb3/tianon/busybox/arch-pipeline.groovy#L68-L71