### PR TITLE
disable hwaccel closing issue with sha1sum and sha256sum

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -265,8 +265,8 @@ RUN set -eux; \
 		CONFIG_FEATURE_UTMP \
 		CONFIG_FEATURE_WTMP \
 {{ ) else "" end -}}
-		CONFIG_SHA1_HWACCEL \
-		CONFIG_SHA256_HWACCEL \
+# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
+		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -265,6 +265,8 @@ RUN set -eux; \
 		CONFIG_FEATURE_UTMP \
 		CONFIG_FEATURE_WTMP \
 {{ ) else "" end -}}
+		CONFIG_SHA1_HWACCEL \
+		CONFIG_SHA256_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -53,6 +53,8 @@ RUN set -eux; \
 	\
 	unsetConfs=' \
 		CONFIG_FEATURE_SYNC_FANCY \
+# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
+		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -61,6 +61,8 @@ RUN set -eux; \
 		CONFIG_FEATURE_INETD_RPC \
 		CONFIG_FEATURE_UTMP \
 		CONFIG_FEATURE_WTMP \
+# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
+		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -239,6 +239,8 @@ RUN set -eux; \
 	\
 	unsetConfs=' \
 		CONFIG_FEATURE_SYNC_FANCY \
+# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
+		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -53,6 +53,8 @@ RUN set -eux; \
 	\
 	unsetConfs=' \
 		CONFIG_FEATURE_SYNC_FANCY \
+# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
+		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -61,6 +61,8 @@ RUN set -eux; \
 		CONFIG_FEATURE_INETD_RPC \
 		CONFIG_FEATURE_UTMP \
 		CONFIG_FEATURE_WTMP \
+# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
+		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -239,6 +239,8 @@ RUN set -eux; \
 	\
 	unsetConfs=' \
 		CONFIG_FEATURE_SYNC_FANCY \
+# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
+		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \


### PR DESCRIPTION
This is meant to disable the optional, on-by-default hardware acceleration added in 1.36.0 to support the sha1sum and sha256sum functions. There is an issue where github actions hosted runners have processor feature sets that confuses acceleration detection. Alpine has also disabled this acceleration in their busybox package. Details in the issue below. Once the fix can be implemented upstream it would be ok to back this change out.

This is my first PR to docker-library so I don't know if I'm supposed to do something after editing the `Dockerfile-builder.template`.

closes: #166