### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -23,7 +23,7 @@ RUN set -eux; \
 		bzip2 \
 		curl \
 		gcc \
-		gnupg dirmngr \
+		gnupg \
 		make \
 		patch \
 	; \

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -12,7 +12,7 @@ RUN set -eux; \
 		bzip2 \
 		curl \
 		gcc \
-		gnupg dirmngr \
+		gnupg \
 		make \
 		patch \
 	; \

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -12,7 +12,7 @@ RUN set -eux; \
 		bzip2 \
 		curl \
 		gcc \
-		gnupg dirmngr \
+		gnupg \
 		make \
 		patch \
 	; \

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -12,7 +12,7 @@ RUN set -eux; \
 		bzip2 \
 		curl \
 		gcc \
-		gnupg dirmngr \
+		gnupg \
 		make \
 		patch \
 	; \

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -12,7 +12,7 @@ RUN set -eux; \
 		bzip2 \
 		curl \
 		gcc \
-		gnupg dirmngr \
+		gnupg \
 		make \
 		patch \
 	; \


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu have 2.2.x 😇).