### PR TITLE
Update to 1.36.1

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -265,8 +265,10 @@ RUN set -eux; \
 		CONFIG_FEATURE_UTMP \
 		CONFIG_FEATURE_WTMP \
 {{ ) else "" end -}}
+{{ if .version | startswith("1.35.") then ( -}}
 # disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
 		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
+{{ ) else "" end -}}
 	'; \
 	\
 	make defconfig; \

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -24,9 +24,9 @@ RUN set -eux; \
 # sub   1024g/2C766641 2006-12-12
 RUN mkdir -p ~/.gnupg && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys C9E9416F76E610DBD09D040F47B70C55ACC9965B
 
-# https://busybox.net: 3 January 2023
-ENV BUSYBOX_VERSION 1.36.0
-ENV BUSYBOX_SHA256 542750c8af7cb2630e201780b4f99f3dcceeb06f505b479ec68241c1e6af61a5
+# https://busybox.net: 19 May 2023
+ENV BUSYBOX_VERSION 1.36.1
+ENV BUSYBOX_SHA256 b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
 
 RUN set -eux; \
 	tarball="busybox-${BUSYBOX_VERSION}.tar.bz2"; \
@@ -53,8 +53,6 @@ RUN set -eux; \
 	\
 	unsetConfs=' \
 		CONFIG_FEATURE_SYNC_FANCY \
-# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
-		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -26,9 +26,9 @@ RUN set -eux; \
 # sub   1024g/2C766641 2006-12-12
 RUN mkdir -p ~/.gnupg && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys C9E9416F76E610DBD09D040F47B70C55ACC9965B
 
-# https://busybox.net: 3 January 2023
-ENV BUSYBOX_VERSION 1.36.0
-ENV BUSYBOX_SHA256 542750c8af7cb2630e201780b4f99f3dcceeb06f505b479ec68241c1e6af61a5
+# https://busybox.net: 19 May 2023
+ENV BUSYBOX_VERSION 1.36.1
+ENV BUSYBOX_SHA256 b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
 
 RUN set -eux; \
 	tarball="busybox-${BUSYBOX_VERSION}.tar.bz2"; \
@@ -61,8 +61,6 @@ RUN set -eux; \
 		CONFIG_FEATURE_INETD_RPC \
 		CONFIG_FEATURE_UTMP \
 		CONFIG_FEATURE_WTMP \
-# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
-		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -210,9 +210,9 @@ ENV PATH /usr/src/buildroot/output/host/usr/bin:$PATH
 # sub   1024g/2C766641 2006-12-12
 RUN mkdir -p ~/.gnupg && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys C9E9416F76E610DBD09D040F47B70C55ACC9965B
 
-# https://busybox.net: 3 January 2023
-ENV BUSYBOX_VERSION 1.36.0
-ENV BUSYBOX_SHA256 542750c8af7cb2630e201780b4f99f3dcceeb06f505b479ec68241c1e6af61a5
+# https://busybox.net: 19 May 2023
+ENV BUSYBOX_VERSION 1.36.1
+ENV BUSYBOX_SHA256 b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314
 
 RUN set -eux; \
 	tarball="busybox-${BUSYBOX_VERSION}.tar.bz2"; \
@@ -239,8 +239,6 @@ RUN set -eux; \
 	\
 	unsetConfs=' \
 		CONFIG_FEATURE_SYNC_FANCY \
-# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
-		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
 	'; \
 	\
 	make defconfig; \

--- a/versions.json
+++ b/versions.json
@@ -3,15 +3,15 @@
     "buildroot": {
       "version": "2023.02"
     },
-    "date": "3 January 2023",
-    "sha256": "542750c8af7cb2630e201780b4f99f3dcceeb06f505b479ec68241c1e6af61a5",
-    "stability": "unstable",
+    "date": "19 May 2023",
+    "sha256": "b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314",
+    "stability": "stable",
     "variants": [
       "glibc",
       "uclibc",
       "musl"
     ],
-    "version": "1.36.0"
+    "version": "1.36.1"
   },
   "latest-1": {
     "buildroot": {


### PR DESCRIPTION
https://busybox.net/

> 19 May 2023 -- BusyBox 1.36.1 (stable)
> [BusyBox 1.36.1](https://busybox.net/downloads/busybox-1.36.1.tar.bz2). ([git](https://git.busybox.net/busybox/tree/?h=1_36_stable))
>
> Bug fix release. 1.36.1 has fixes for line editing, detection of hardware sha1/sha256 support, unzip (do not create suid/sgid files unless -K), shell (printf and sleep with no args, handing of SIGINT in sleep), ed.

(Although it looks like Git hasn't been updated yet -- no 1_36_1 tag nor relevant "releasing" commits in the linked branch :sweat_smile:)