### PR TITLE
Update buildroot to 2023.11.1

### DIFF
--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -134,7 +134,7 @@ RUN set -eux; \
 
 # install a few extra files from buildroot (/etc/passwd, etc)
 RUN set -eux; \
-	buildrootVersion='2023.11'; \
+	buildrootVersion='2023.11.1'; \
 	for file in \
 		system/device_table.txt \
 		system/skeleton/etc/group \

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -114,7 +114,7 @@ RUN set -eux; \
 
 # install a few extra files from buildroot (/etc/passwd, etc)
 RUN set -eux; \
-	buildrootVersion='2023.11'; \
+	buildrootVersion='2023.11.1'; \
 	for file in \
 		system/device_table.txt \
 		system/skeleton/etc/group \

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -44,7 +44,7 @@ RUN mkdir -p ~/.gnupg && gpg --batch --keyserver keyserver.ubuntu.com --recv-key
 
 # https://buildroot.org/download.html
 # https://buildroot.org/downloads/?C=M;O=D
-ENV BUILDROOT_VERSION 2023.11
+ENV BUILDROOT_VERSION 2023.11.1
 
 RUN set -eux; \
 	tarball="buildroot-${BUILDROOT_VERSION}.tar.xz"; \

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -132,7 +132,7 @@ RUN set -eux; \
 
 # install a few extra files from buildroot (/etc/passwd, etc)
 RUN set -eux; \
-	buildrootVersion='2023.11'; \
+	buildrootVersion='2023.11.1'; \
 	for file in \
 		system/device_table.txt \
 		system/skeleton/etc/group \

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -112,7 +112,7 @@ RUN set -eux; \
 
 # install a few extra files from buildroot (/etc/passwd, etc)
 RUN set -eux; \
-	buildrootVersion='2023.11'; \
+	buildrootVersion='2023.11.1'; \
 	for file in \
 		system/device_table.txt \
 		system/skeleton/etc/group \

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -44,7 +44,7 @@ RUN mkdir -p ~/.gnupg && gpg --batch --keyserver keyserver.ubuntu.com --recv-key
 
 # https://buildroot.org/download.html
 # https://buildroot.org/downloads/?C=M;O=D
-ENV BUILDROOT_VERSION 2023.11
+ENV BUILDROOT_VERSION 2023.11.1
 
 RUN set -eux; \
 	tarball="buildroot-${BUILDROOT_VERSION}.tar.xz"; \

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
   "latest": {
     "buildroot": {
-      "version": "2023.11"
+      "version": "2023.11.1"
     },
     "date": "19 May 2023",
     "sha256": "b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314",
@@ -15,7 +15,7 @@
   },
   "latest-1": {
     "buildroot": {
-      "version": "2023.11"
+      "version": "2023.11.1"
     },
     "date": "26 December 2021",
     "sha256": "faeeb244c35a348a334f4a59e44626ee870fb07b6884d68c10ae8bc19f83a694",


### PR DESCRIPTION
@LaurentGoderre this shouldn't actually change much (if anything) in our images, so we should save merging and rebuilding with this for when we're ready with your updated SBOM scanner changes :eyes: