### PR TITLE
Update metadata

### DIFF
--- a/latest-1/glibc/arm32v5/blobs/sha256/3cb1d74becebf3031646d8d4822728973482e2e56b73a6669243a52aaf1544ff
+++ b/latest-1/glibc/arm32v5/blobs/sha256/3cb1d74becebf3031646d8d4822728973482e2e56b73a6669243a52aaf1544ff
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/glibc/arm32v5/blobs/sha256/6f419b164f0f391706417345127f8bbf8d7b747e24283b6a5ee48a348d5c157a
+++ b/latest-1/glibc/arm32v5/blobs/sha256/6f419b164f0f391706417345127f8bbf8d7b747e24283b6a5ee48a348d5c157a
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/glibc/arm32v5/blobs/sha256/b59bb812a84f8d3e6554de2334ce709ce2ddd45b2122f4243d195d8311296290
+++ b/latest-1/glibc/arm32v5/blobs/sha256/b59bb812a84f8d3e6554de2334ce709ce2ddd45b2122f4243d195d8311296290
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/glibc/arm32v5/image-config.json
+++ b/latest-1/glibc/arm32v5/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:eaa02c8043d09a8d09ee3690513d80c539cd7816d45d43f06a7af2a08f3414b6"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v5"
+}

--- a/latest-1/glibc/arm32v5/image-manifest.json
+++ b/latest-1/glibc/arm32v5/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:6f419b164f0f391706417345127f8bbf8d7b747e24283b6a5ee48a348d5c157a",
+		"size": 388
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:b59bb812a84f8d3e6554de2334ce709ce2ddd45b2122f4243d195d8311296290",
+			"size": 1772716
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-glibc"
+	}
+}

--- a/latest-1/glibc/arm32v5/index.json
+++ b/latest-1/glibc/arm32v5/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:3cb1d74becebf3031646d8d4822728973482e2e56b73a6669243a52aaf1544ff",
+			"size": 610,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v5"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-glibc",
+				"io.containerd.image.name": "busybox:1.35.0-glibc"
+			}
+		}
+	]
+}

--- a/latest-1/glibc/arm32v5/oci-layout
+++ b/latest-1/glibc/arm32v5/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/glibc/arm32v7/blobs/sha256/9ad13fde87c1a28d0f81f25851b9bbf442691310607311ec8c563e2103536e4f
+++ b/latest-1/glibc/arm32v7/blobs/sha256/9ad13fde87c1a28d0f81f25851b9bbf442691310607311ec8c563e2103536e4f
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/glibc/arm32v7/blobs/sha256/bbcae909f65630db46bda0bbbbdca543c71fec5233df65620405f8e11b831d9f
+++ b/latest-1/glibc/arm32v7/blobs/sha256/bbcae909f65630db46bda0bbbbdca543c71fec5233df65620405f8e11b831d9f
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/glibc/arm32v7/blobs/sha256/d335b8de554e790e78e0b1a84e0b148c3ac7ada67f91b0c22b34b3c3dd946b8e
+++ b/latest-1/glibc/arm32v7/blobs/sha256/d335b8de554e790e78e0b1a84e0b148c3ac7ada67f91b0c22b34b3c3dd946b8e
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/glibc/arm32v7/image-config.json
+++ b/latest-1/glibc/arm32v7/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:07d1e79cb266ebbcfec899ee0d8e1e68abfffb222ec12347c30665c5f8adeaae"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v7"
+}

--- a/latest-1/glibc/arm32v7/image-manifest.json
+++ b/latest-1/glibc/arm32v7/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:d335b8de554e790e78e0b1a84e0b148c3ac7ada67f91b0c22b34b3c3dd946b8e",
+		"size": 388
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:bbcae909f65630db46bda0bbbbdca543c71fec5233df65620405f8e11b831d9f",
+			"size": 1550275
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-glibc"
+	}
+}

--- a/latest-1/glibc/arm32v7/index.json
+++ b/latest-1/glibc/arm32v7/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:9ad13fde87c1a28d0f81f25851b9bbf442691310607311ec8c563e2103536e4f",
+			"size": 610,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v7"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-glibc",
+				"io.containerd.image.name": "busybox:1.35.0-glibc"
+			}
+		}
+	]
+}

--- a/latest-1/glibc/arm32v7/oci-layout
+++ b/latest-1/glibc/arm32v7/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/glibc/arm64v8/blobs/sha256/89bf88b6ae759b3cf19913ea54ddba17e65a6efa7d1d86063a5d830015e87c2f
+++ b/latest-1/glibc/arm64v8/blobs/sha256/89bf88b6ae759b3cf19913ea54ddba17e65a6efa7d1d86063a5d830015e87c2f
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/glibc/arm64v8/blobs/sha256/8a65b3d2374bd347c9877811ef0ea7ab3db081a84430267d23447e39cd90c7c4
+++ b/latest-1/glibc/arm64v8/blobs/sha256/8a65b3d2374bd347c9877811ef0ea7ab3db081a84430267d23447e39cd90c7c4
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/glibc/arm64v8/blobs/sha256/d4bedb27268632135578a01fec33debcd0f5453380260edc6a6eb2c3838adfb1
+++ b/latest-1/glibc/arm64v8/blobs/sha256/d4bedb27268632135578a01fec33debcd0f5453380260edc6a6eb2c3838adfb1
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/glibc/arm64v8/image-config.json
+++ b/latest-1/glibc/arm64v8/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:f2da5330b1bfb13b1bb4242bd9ddf35f3fe5e747afff7533b3960801d87a4f44"
+		]
+	},
+	"architecture": "arm64",
+	"os": "linux",
+	"variant": "v8"
+}

--- a/latest-1/glibc/arm64v8/image-manifest.json
+++ b/latest-1/glibc/arm64v8/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:89bf88b6ae759b3cf19913ea54ddba17e65a6efa7d1d86063a5d830015e87c2f",
+		"size": 390
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:8a65b3d2374bd347c9877811ef0ea7ab3db081a84430267d23447e39cd90c7c4",
+			"size": 1837213
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-glibc"
+	}
+}

--- a/latest-1/glibc/arm64v8/index.json
+++ b/latest-1/glibc/arm64v8/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:d4bedb27268632135578a01fec33debcd0f5453380260edc6a6eb2c3838adfb1",
+			"size": 610,
+			"platform": {
+				"architecture": "arm64",
+				"os": "linux",
+				"variant": "v8"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-glibc",
+				"io.containerd.image.name": "busybox:1.35.0-glibc"
+			}
+		}
+	]
+}

--- a/latest-1/glibc/arm64v8/oci-layout
+++ b/latest-1/glibc/arm64v8/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/glibc/i386/blobs/sha256/004fc0f9ab197ba0512ae7129a3014bb6a2e234b0fe72ac89f1715736e04b661
+++ b/latest-1/glibc/i386/blobs/sha256/004fc0f9ab197ba0512ae7129a3014bb6a2e234b0fe72ac89f1715736e04b661
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/glibc/i386/blobs/sha256/797063ccd797153a3ed4aca5dbf06ff120797eb24d9d501a40eaab302cc1f743
+++ b/latest-1/glibc/i386/blobs/sha256/797063ccd797153a3ed4aca5dbf06ff120797eb24d9d501a40eaab302cc1f743
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/glibc/i386/blobs/sha256/90e9da41711353fae11232db745a5175100b82e18226c70c2c8b9cd08fdc3338
+++ b/latest-1/glibc/i386/blobs/sha256/90e9da41711353fae11232db745a5175100b82e18226c70c2c8b9cd08fdc3338
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/glibc/i386/image-config.json
+++ b/latest-1/glibc/i386/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:1e52f6598609072284fa4a482de4adc798e99629e5ace025e785d6f9b17b7e04"
+		]
+	},
+	"architecture": "386",
+	"os": "linux"
+}

--- a/latest-1/glibc/i386/image-manifest.json
+++ b/latest-1/glibc/i386/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:004fc0f9ab197ba0512ae7129a3014bb6a2e234b0fe72ac89f1715736e04b661",
+		"size": 370
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:90e9da41711353fae11232db745a5175100b82e18226c70c2c8b9cd08fdc3338",
+			"size": 2203641
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-glibc"
+	}
+}

--- a/latest-1/glibc/i386/index.json
+++ b/latest-1/glibc/i386/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:797063ccd797153a3ed4aca5dbf06ff120797eb24d9d501a40eaab302cc1f743",
+			"size": 610,
+			"platform": {
+				"architecture": "386",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-glibc",
+				"io.containerd.image.name": "busybox:1.35.0-glibc"
+			}
+		}
+	]
+}

--- a/latest-1/glibc/i386/oci-layout
+++ b/latest-1/glibc/i386/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/glibc/mips64le/blobs/sha256/0905a181f6a06656547a117e6ddf579ddc6706a18ec7334c91af5d737b9b6c3a
+++ b/latest-1/glibc/mips64le/blobs/sha256/0905a181f6a06656547a117e6ddf579ddc6706a18ec7334c91af5d737b9b6c3a
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/glibc/mips64le/blobs/sha256/4f42e99c852996a8f560b737046a8501fb714664914b9aab6c08796739497195
+++ b/latest-1/glibc/mips64le/blobs/sha256/4f42e99c852996a8f560b737046a8501fb714664914b9aab6c08796739497195
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/glibc/mips64le/blobs/sha256/bde827b12c95d1ece79ad25f0839a526e44b3fe4e8148f21957b007c3b8e5488
+++ b/latest-1/glibc/mips64le/blobs/sha256/bde827b12c95d1ece79ad25f0839a526e44b3fe4e8148f21957b007c3b8e5488
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/glibc/mips64le/image-config.json
+++ b/latest-1/glibc/mips64le/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:f37bc682975e632b31fa72cadbc67a05437bc3f4028f2ceea1e032b4b4d357d4"
+		]
+	},
+	"architecture": "mips64le",
+	"os": "linux"
+}

--- a/latest-1/glibc/mips64le/image-manifest.json
+++ b/latest-1/glibc/mips64le/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:0905a181f6a06656547a117e6ddf579ddc6706a18ec7334c91af5d737b9b6c3a",
+		"size": 375
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:bde827b12c95d1ece79ad25f0839a526e44b3fe4e8148f21957b007c3b8e5488",
+			"size": 2072932
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-glibc"
+	}
+}

--- a/latest-1/glibc/mips64le/index.json
+++ b/latest-1/glibc/mips64le/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:4f42e99c852996a8f560b737046a8501fb714664914b9aab6c08796739497195",
+			"size": 610,
+			"platform": {
+				"architecture": "mips64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-glibc",
+				"io.containerd.image.name": "busybox:1.35.0-glibc"
+			}
+		}
+	]
+}

--- a/latest-1/glibc/mips64le/oci-layout
+++ b/latest-1/glibc/mips64le/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/glibc/ppc64le/blobs/sha256/6d3169996020ba9aa40afce916e9a6c1723abbbb78c8f52a6e9fbfd839a17b14
+++ b/latest-1/glibc/ppc64le/blobs/sha256/6d3169996020ba9aa40afce916e9a6c1723abbbb78c8f52a6e9fbfd839a17b14
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/glibc/ppc64le/blobs/sha256/939360b56012939445a199de1b9637492b70d458611d2886a662cce597fb63e5
+++ b/latest-1/glibc/ppc64le/blobs/sha256/939360b56012939445a199de1b9637492b70d458611d2886a662cce597fb63e5
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/glibc/ppc64le/blobs/sha256/f586dbc66d141ea9ef6ddaa0507e54096423fe678b47b1233ff74db86772a082
+++ b/latest-1/glibc/ppc64le/blobs/sha256/f586dbc66d141ea9ef6ddaa0507e54096423fe678b47b1233ff74db86772a082
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/glibc/ppc64le/image-config.json
+++ b/latest-1/glibc/ppc64le/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:43f9026b612fac75c6e95a997e488c1e9c5bcf71ff3e982361b963a9c4be09d0"
+		]
+	},
+	"architecture": "ppc64le",
+	"os": "linux"
+}

--- a/latest-1/glibc/ppc64le/image-manifest.json
+++ b/latest-1/glibc/ppc64le/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:939360b56012939445a199de1b9637492b70d458611d2886a662cce597fb63e5",
+		"size": 374
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:6d3169996020ba9aa40afce916e9a6c1723abbbb78c8f52a6e9fbfd839a17b14",
+			"size": 2456149
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-glibc"
+	}
+}

--- a/latest-1/glibc/ppc64le/index.json
+++ b/latest-1/glibc/ppc64le/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:f586dbc66d141ea9ef6ddaa0507e54096423fe678b47b1233ff74db86772a082",
+			"size": 610,
+			"platform": {
+				"architecture": "ppc64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-glibc",
+				"io.containerd.image.name": "busybox:1.35.0-glibc"
+			}
+		}
+	]
+}

--- a/latest-1/glibc/ppc64le/oci-layout
+++ b/latest-1/glibc/ppc64le/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/glibc/s390x/blobs/sha256/344b9f13185cb939c9bda40fc996e1a7b90165a18f73c7eb882ee5328d3f8793
+++ b/latest-1/glibc/s390x/blobs/sha256/344b9f13185cb939c9bda40fc996e1a7b90165a18f73c7eb882ee5328d3f8793
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/glibc/s390x/blobs/sha256/429bcbf2011c582a734b9f357df8aa5cbbf7e2c52e50e7016cb7a3321652805c
+++ b/latest-1/glibc/s390x/blobs/sha256/429bcbf2011c582a734b9f357df8aa5cbbf7e2c52e50e7016cb7a3321652805c
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/glibc/s390x/blobs/sha256/53f3bc7ed56972af3119717c11d0b8863aa4d711e0e6d39dfd993eee49b4a48a
+++ b/latest-1/glibc/s390x/blobs/sha256/53f3bc7ed56972af3119717c11d0b8863aa4d711e0e6d39dfd993eee49b4a48a
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/glibc/s390x/image-config.json
+++ b/latest-1/glibc/s390x/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:13376822bf050b20c6ff9c38719ddcd941794259e9c191c12b31e34643f0c659"
+		]
+	},
+	"architecture": "s390x",
+	"os": "linux"
+}

--- a/latest-1/glibc/s390x/image-manifest.json
+++ b/latest-1/glibc/s390x/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:53f3bc7ed56972af3119717c11d0b8863aa4d711e0e6d39dfd993eee49b4a48a",
+		"size": 372
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:344b9f13185cb939c9bda40fc996e1a7b90165a18f73c7eb882ee5328d3f8793",
+			"size": 1876033
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-glibc"
+	}
+}

--- a/latest-1/glibc/s390x/index.json
+++ b/latest-1/glibc/s390x/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:429bcbf2011c582a734b9f357df8aa5cbbf7e2c52e50e7016cb7a3321652805c",
+			"size": 610,
+			"platform": {
+				"architecture": "s390x",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-glibc",
+				"io.containerd.image.name": "busybox:1.35.0-glibc"
+			}
+		}
+	]
+}

--- a/latest-1/glibc/s390x/oci-layout
+++ b/latest-1/glibc/s390x/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/musl/arm32v6/blobs/sha256/461d411de7876cfdf128f811777c85dd543305ccd7d56c8cfc3c1dfa5946a023
+++ b/latest-1/musl/arm32v6/blobs/sha256/461d411de7876cfdf128f811777c85dd543305ccd7d56c8cfc3c1dfa5946a023
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/musl/arm32v6/blobs/sha256/61f59067cdfe0c545fae7502917047079f6a876e78dcd0187c39928a1836a7d1
+++ b/latest-1/musl/arm32v6/blobs/sha256/61f59067cdfe0c545fae7502917047079f6a876e78dcd0187c39928a1836a7d1
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/musl/arm32v6/blobs/sha256/94f90368019e11514e9875c7b3593421417856e2b498d27aaa8d0b5b2f87b4ea
+++ b/latest-1/musl/arm32v6/blobs/sha256/94f90368019e11514e9875c7b3593421417856e2b498d27aaa8d0b5b2f87b4ea
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/musl/arm32v6/image-config.json
+++ b/latest-1/musl/arm32v6/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:bb709a0f3f3e1858b9c870c33bfcf6ee85441d06749419c6b2498d7cadda23bb"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v6"
+}

--- a/latest-1/musl/arm32v6/image-manifest.json
+++ b/latest-1/musl/arm32v6/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:94f90368019e11514e9875c7b3593421417856e2b498d27aaa8d0b5b2f87b4ea",
+		"size": 391
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:461d411de7876cfdf128f811777c85dd543305ccd7d56c8cfc3c1dfa5946a023",
+			"size": 944715
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-musl"
+	}
+}

--- a/latest-1/musl/arm32v6/index.json
+++ b/latest-1/musl/arm32v6/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:61f59067cdfe0c545fae7502917047079f6a876e78dcd0187c39928a1836a7d1",
+			"size": 608,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v6"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-musl",
+				"io.containerd.image.name": "busybox:1.35.0-musl"
+			}
+		}
+	]
+}

--- a/latest-1/musl/arm32v6/oci-layout
+++ b/latest-1/musl/arm32v6/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/musl/arm32v7/blobs/sha256/029b6487ed7f95712a2317b02fd31472ed9d382733b25df1c71c777208b5057b
+++ b/latest-1/musl/arm32v7/blobs/sha256/029b6487ed7f95712a2317b02fd31472ed9d382733b25df1c71c777208b5057b
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/musl/arm32v7/blobs/sha256/2bcb8e8a21628e66f548247868e3165ab6a60464c4ff9b4a0e29b04af369aec4
+++ b/latest-1/musl/arm32v7/blobs/sha256/2bcb8e8a21628e66f548247868e3165ab6a60464c4ff9b4a0e29b04af369aec4
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/musl/arm32v7/blobs/sha256/b3b36963e5429889ca5dce40d4a861fc29a82367e9ba15b5f59e8f8bb99e6520
+++ b/latest-1/musl/arm32v7/blobs/sha256/b3b36963e5429889ca5dce40d4a861fc29a82367e9ba15b5f59e8f8bb99e6520
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/musl/arm32v7/image-config.json
+++ b/latest-1/musl/arm32v7/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:6744b57c3c8c61f31ba511e0475c022c32aef4555ad17d7dcbe7f1eca806d027"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v7"
+}

--- a/latest-1/musl/arm32v7/image-manifest.json
+++ b/latest-1/musl/arm32v7/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:2bcb8e8a21628e66f548247868e3165ab6a60464c4ff9b4a0e29b04af369aec4",
+		"size": 391
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:029b6487ed7f95712a2317b02fd31472ed9d382733b25df1c71c777208b5057b",
+			"size": 840429
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-musl"
+	}
+}

--- a/latest-1/musl/arm32v7/index.json
+++ b/latest-1/musl/arm32v7/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:b3b36963e5429889ca5dce40d4a861fc29a82367e9ba15b5f59e8f8bb99e6520",
+			"size": 608,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v7"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-musl",
+				"io.containerd.image.name": "busybox:1.35.0-musl"
+			}
+		}
+	]
+}

--- a/latest-1/musl/arm32v7/oci-layout
+++ b/latest-1/musl/arm32v7/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/musl/arm64v8/blobs/sha256/0bd1caaaf87dc972fd159b368a85159b4d7602436e014fe7c91a9d08cc495ccc
+++ b/latest-1/musl/arm64v8/blobs/sha256/0bd1caaaf87dc972fd159b368a85159b4d7602436e014fe7c91a9d08cc495ccc
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/musl/arm64v8/blobs/sha256/6d2fe0e236eb16c5c3a90fa53b8a9af854037e669bc756f503a0b29c09919f61
+++ b/latest-1/musl/arm64v8/blobs/sha256/6d2fe0e236eb16c5c3a90fa53b8a9af854037e669bc756f503a0b29c09919f61
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/musl/arm64v8/blobs/sha256/ea61d885c0901133f1e300c9e4191c90da4a540061626a6cacfc1e48625646c0
+++ b/latest-1/musl/arm64v8/blobs/sha256/ea61d885c0901133f1e300c9e4191c90da4a540061626a6cacfc1e48625646c0
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/musl/arm64v8/image-config.json
+++ b/latest-1/musl/arm64v8/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:d3080fb5750455bd03c5a5113e363590eacc93d079044c951c5e07e646735b22"
+		]
+	},
+	"architecture": "arm64",
+	"os": "linux",
+	"variant": "v8"
+}

--- a/latest-1/musl/arm64v8/image-manifest.json
+++ b/latest-1/musl/arm64v8/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:6d2fe0e236eb16c5c3a90fa53b8a9af854037e669bc756f503a0b29c09919f61",
+		"size": 393
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:0bd1caaaf87dc972fd159b368a85159b4d7602436e014fe7c91a9d08cc495ccc",
+			"size": 885531
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-musl"
+	}
+}

--- a/latest-1/musl/arm64v8/index.json
+++ b/latest-1/musl/arm64v8/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:ea61d885c0901133f1e300c9e4191c90da4a540061626a6cacfc1e48625646c0",
+			"size": 608,
+			"platform": {
+				"architecture": "arm64",
+				"os": "linux",
+				"variant": "v8"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-musl",
+				"io.containerd.image.name": "busybox:1.35.0-musl"
+			}
+		}
+	]
+}

--- a/latest-1/musl/arm64v8/oci-layout
+++ b/latest-1/musl/arm64v8/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/musl/i386/blobs/sha256/1401aebcbef5061554147344c743bfa3e34d0c3701613cd23ae67cd462ca7efa
+++ b/latest-1/musl/i386/blobs/sha256/1401aebcbef5061554147344c743bfa3e34d0c3701613cd23ae67cd462ca7efa
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/musl/i386/blobs/sha256/2346ca148c28f1e21bf8ecb275532ca2997f9a3f757cce11899f3ba78054a28f
+++ b/latest-1/musl/i386/blobs/sha256/2346ca148c28f1e21bf8ecb275532ca2997f9a3f757cce11899f3ba78054a28f
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/musl/i386/blobs/sha256/cee43a080bb18a82038a6fb2807d0444e7fedebae6b3cc980c574b6d91b2e419
+++ b/latest-1/musl/i386/blobs/sha256/cee43a080bb18a82038a6fb2807d0444e7fedebae6b3cc980c574b6d91b2e419
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/musl/i386/image-config.json
+++ b/latest-1/musl/i386/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:118ca2b73cebd2fc9b318b209f3f5c6bbfcac04eb02dbd070187faf5c7ecab30"
+		]
+	},
+	"architecture": "386",
+	"os": "linux"
+}

--- a/latest-1/musl/i386/image-manifest.json
+++ b/latest-1/musl/i386/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:1401aebcbef5061554147344c743bfa3e34d0c3701613cd23ae67cd462ca7efa",
+		"size": 373
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:cee43a080bb18a82038a6fb2807d0444e7fedebae6b3cc980c574b6d91b2e419",
+			"size": 846313
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-musl"
+	}
+}

--- a/latest-1/musl/i386/index.json
+++ b/latest-1/musl/i386/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:2346ca148c28f1e21bf8ecb275532ca2997f9a3f757cce11899f3ba78054a28f",
+			"size": 608,
+			"platform": {
+				"architecture": "386",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-musl",
+				"io.containerd.image.name": "busybox:1.35.0-musl"
+			}
+		}
+	]
+}

--- a/latest-1/musl/i386/oci-layout
+++ b/latest-1/musl/i386/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/musl/ppc64le/blobs/sha256/2b0eae1c3a0bce36e751419cb9fc7803cbe1d8e334d5be613f1b1c0f85cb1632
+++ b/latest-1/musl/ppc64le/blobs/sha256/2b0eae1c3a0bce36e751419cb9fc7803cbe1d8e334d5be613f1b1c0f85cb1632
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/musl/ppc64le/blobs/sha256/50e28b8b0aaef7cbe0bb1891030a2e9e8505f6c799a65e1d95cd24d64e2c5154
+++ b/latest-1/musl/ppc64le/blobs/sha256/50e28b8b0aaef7cbe0bb1891030a2e9e8505f6c799a65e1d95cd24d64e2c5154
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/musl/ppc64le/blobs/sha256/b752895a38028c1a4f8b64ffb1963c7ce1a10164b4982f512a84bffa2b170022
+++ b/latest-1/musl/ppc64le/blobs/sha256/b752895a38028c1a4f8b64ffb1963c7ce1a10164b4982f512a84bffa2b170022
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/musl/ppc64le/image-config.json
+++ b/latest-1/musl/ppc64le/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:06005955c7d9b617c66b11d008be565b373d324f5d94898cc517ba6647986697"
+		]
+	},
+	"architecture": "ppc64le",
+	"os": "linux"
+}

--- a/latest-1/musl/ppc64le/image-manifest.json
+++ b/latest-1/musl/ppc64le/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:2b0eae1c3a0bce36e751419cb9fc7803cbe1d8e334d5be613f1b1c0f85cb1632",
+		"size": 377
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:50e28b8b0aaef7cbe0bb1891030a2e9e8505f6c799a65e1d95cd24d64e2c5154",
+			"size": 935889
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-musl"
+	}
+}

--- a/latest-1/musl/ppc64le/index.json
+++ b/latest-1/musl/ppc64le/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:b752895a38028c1a4f8b64ffb1963c7ce1a10164b4982f512a84bffa2b170022",
+			"size": 608,
+			"platform": {
+				"architecture": "ppc64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-musl",
+				"io.containerd.image.name": "busybox:1.35.0-musl"
+			}
+		}
+	]
+}

--- a/latest-1/musl/ppc64le/oci-layout
+++ b/latest-1/musl/ppc64le/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/musl/s390x/blobs/sha256/358276dc67b399f5577d7a12a011c17709899ede9cdeab5f4e0cbffa74494fcb
+++ b/latest-1/musl/s390x/blobs/sha256/358276dc67b399f5577d7a12a011c17709899ede9cdeab5f4e0cbffa74494fcb
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/musl/s390x/blobs/sha256/3ba95ec9a2332e09372f83ed4a48d0ac9397180556368d6089e97b4c22328a3f
+++ b/latest-1/musl/s390x/blobs/sha256/3ba95ec9a2332e09372f83ed4a48d0ac9397180556368d6089e97b4c22328a3f
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/musl/s390x/blobs/sha256/9ee7e8257727eaa8e190a19851524f3ab13f909f4705e4ecbc0b38fcac1639f4
+++ b/latest-1/musl/s390x/blobs/sha256/9ee7e8257727eaa8e190a19851524f3ab13f909f4705e4ecbc0b38fcac1639f4
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/musl/s390x/image-config.json
+++ b/latest-1/musl/s390x/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:9233aef43ebf02c228c4a2aa07abb50e3b5eea91ae2a384f0dd11ea98260d1ae"
+		]
+	},
+	"architecture": "s390x",
+	"os": "linux"
+}

--- a/latest-1/musl/s390x/image-manifest.json
+++ b/latest-1/musl/s390x/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:358276dc67b399f5577d7a12a011c17709899ede9cdeab5f4e0cbffa74494fcb",
+		"size": 375
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:9ee7e8257727eaa8e190a19851524f3ab13f909f4705e4ecbc0b38fcac1639f4",
+			"size": 916954
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-musl"
+	}
+}

--- a/latest-1/musl/s390x/index.json
+++ b/latest-1/musl/s390x/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:3ba95ec9a2332e09372f83ed4a48d0ac9397180556368d6089e97b4c22328a3f",
+			"size": 608,
+			"platform": {
+				"architecture": "s390x",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-musl",
+				"io.containerd.image.name": "busybox:1.35.0-musl"
+			}
+		}
+	]
+}

--- a/latest-1/musl/s390x/oci-layout
+++ b/latest-1/musl/s390x/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/uclibc/arm32v5/blobs/sha256/061baea95096df67af0fc29e9937847ed58ccc1d56acea395b67771e7f4986ae
+++ b/latest-1/uclibc/arm32v5/blobs/sha256/061baea95096df67af0fc29e9937847ed58ccc1d56acea395b67771e7f4986ae
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/uclibc/arm32v5/blobs/sha256/3bb1b0a88048e60fe19936f65786af4b21cabb00fbfe0ac7b382829bf5aeddc4
+++ b/latest-1/uclibc/arm32v5/blobs/sha256/3bb1b0a88048e60fe19936f65786af4b21cabb00fbfe0ac7b382829bf5aeddc4
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/uclibc/arm32v5/blobs/sha256/8334aa380a491218db8cf437a7ced14fb21d249c6bdefe7ed942313e4eafc1b6
+++ b/latest-1/uclibc/arm32v5/blobs/sha256/8334aa380a491218db8cf437a7ced14fb21d249c6bdefe7ed942313e4eafc1b6
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/uclibc/arm32v5/image-config.json
+++ b/latest-1/uclibc/arm32v5/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:52006fcd61ca9cf5c4f8269e53e020a6c1eceb7db75848249722385d85847f37"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v5"
+}

--- a/latest-1/uclibc/arm32v5/image-manifest.json
+++ b/latest-1/uclibc/arm32v5/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:8334aa380a491218db8cf437a7ced14fb21d249c6bdefe7ed942313e4eafc1b6",
+		"size": 410
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:061baea95096df67af0fc29e9937847ed58ccc1d56acea395b67771e7f4986ae",
+			"size": 740233
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-uclibc"
+	}
+}

--- a/latest-1/uclibc/arm32v5/index.json
+++ b/latest-1/uclibc/arm32v5/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:3bb1b0a88048e60fe19936f65786af4b21cabb00fbfe0ac7b382829bf5aeddc4",
+			"size": 610,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v5"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-uclibc",
+				"io.containerd.image.name": "busybox:1.35.0-uclibc"
+			}
+		}
+	]
+}

--- a/latest-1/uclibc/arm32v5/oci-layout
+++ b/latest-1/uclibc/arm32v5/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/uclibc/arm32v7/blobs/sha256/22257afa60fc1528c2c6ad730e22ef2f6ba2cbcf71b48a9b0e90ec3f23fc20de
+++ b/latest-1/uclibc/arm32v7/blobs/sha256/22257afa60fc1528c2c6ad730e22ef2f6ba2cbcf71b48a9b0e90ec3f23fc20de
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/uclibc/arm32v7/blobs/sha256/392ca4c865185a559f72a503e3ce6c18b19ef690b40f3b95aff438547165abf3
+++ b/latest-1/uclibc/arm32v7/blobs/sha256/392ca4c865185a559f72a503e3ce6c18b19ef690b40f3b95aff438547165abf3
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/uclibc/arm32v7/blobs/sha256/bc7438374a62f6706adaa7ad9d221598dbb30cd4c2b075b3d121d386c0d00e06
+++ b/latest-1/uclibc/arm32v7/blobs/sha256/bc7438374a62f6706adaa7ad9d221598dbb30cd4c2b075b3d121d386c0d00e06
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/uclibc/arm32v7/image-config.json
+++ b/latest-1/uclibc/arm32v7/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:d5ba958529004b163d8942c5826f3cde3172fbdf696b60cf5e7780acd2b3fbf9"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v7"
+}

--- a/latest-1/uclibc/arm32v7/image-manifest.json
+++ b/latest-1/uclibc/arm32v7/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:bc7438374a62f6706adaa7ad9d221598dbb30cd4c2b075b3d121d386c0d00e06",
+		"size": 410
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:392ca4c865185a559f72a503e3ce6c18b19ef690b40f3b95aff438547165abf3",
+			"size": 705698
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-uclibc"
+	}
+}

--- a/latest-1/uclibc/arm32v7/index.json
+++ b/latest-1/uclibc/arm32v7/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:22257afa60fc1528c2c6ad730e22ef2f6ba2cbcf71b48a9b0e90ec3f23fc20de",
+			"size": 610,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v7"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-uclibc",
+				"io.containerd.image.name": "busybox:1.35.0-uclibc"
+			}
+		}
+	]
+}

--- a/latest-1/uclibc/arm32v7/oci-layout
+++ b/latest-1/uclibc/arm32v7/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/uclibc/arm64v8/blobs/sha256/4aad1045ebaabc1dff86b0b705b172218e4a7ef50b6cdc08c5dffc52a74e7995
+++ b/latest-1/uclibc/arm64v8/blobs/sha256/4aad1045ebaabc1dff86b0b705b172218e4a7ef50b6cdc08c5dffc52a74e7995
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/uclibc/arm64v8/blobs/sha256/70126860441fec96f2369d6b9b3e1cccc6ad8fe30172cba1b04a1ffd1e577bde
+++ b/latest-1/uclibc/arm64v8/blobs/sha256/70126860441fec96f2369d6b9b3e1cccc6ad8fe30172cba1b04a1ffd1e577bde
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/uclibc/arm64v8/blobs/sha256/a94a62cecd0668b205ffd1a72bd582a98239ee3471de8c7093833f6cdd574ee5
+++ b/latest-1/uclibc/arm64v8/blobs/sha256/a94a62cecd0668b205ffd1a72bd582a98239ee3471de8c7093833f6cdd574ee5
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/uclibc/arm64v8/image-config.json
+++ b/latest-1/uclibc/arm64v8/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:2ca30a45d59d33a0832f70583687adc99e9b4433e3e442eb125e156fe4c68eb2"
+		]
+	},
+	"architecture": "arm64",
+	"os": "linux",
+	"variant": "v8"
+}

--- a/latest-1/uclibc/arm64v8/image-manifest.json
+++ b/latest-1/uclibc/arm64v8/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:a94a62cecd0668b205ffd1a72bd582a98239ee3471de8c7093833f6cdd574ee5",
+		"size": 412
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:70126860441fec96f2369d6b9b3e1cccc6ad8fe30172cba1b04a1ffd1e577bde",
+			"size": 800711
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-uclibc"
+	}
+}

--- a/latest-1/uclibc/arm64v8/index.json
+++ b/latest-1/uclibc/arm64v8/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:4aad1045ebaabc1dff86b0b705b172218e4a7ef50b6cdc08c5dffc52a74e7995",
+			"size": 610,
+			"platform": {
+				"architecture": "arm64",
+				"os": "linux",
+				"variant": "v8"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-uclibc",
+				"io.containerd.image.name": "busybox:1.35.0-uclibc"
+			}
+		}
+	]
+}

--- a/latest-1/uclibc/arm64v8/oci-layout
+++ b/latest-1/uclibc/arm64v8/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/uclibc/i386/blobs/sha256/97971c526268d5a742dd179bc514020f97b9ecee36429c1026085ecadac02a16
+++ b/latest-1/uclibc/i386/blobs/sha256/97971c526268d5a742dd179bc514020f97b9ecee36429c1026085ecadac02a16
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/uclibc/i386/blobs/sha256/b303ecb91a5873ec6c0af907fc3828929d68f80b9394f06c2ce51eff1b4d356d
+++ b/latest-1/uclibc/i386/blobs/sha256/b303ecb91a5873ec6c0af907fc3828929d68f80b9394f06c2ce51eff1b4d356d
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/uclibc/i386/blobs/sha256/be09a6572b38da0aaed7ccbe3367d7f1d4dcd9e1c9df00c26f3d291c0455a3c7
+++ b/latest-1/uclibc/i386/blobs/sha256/be09a6572b38da0aaed7ccbe3367d7f1d4dcd9e1c9df00c26f3d291c0455a3c7
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/uclibc/i386/image-config.json
+++ b/latest-1/uclibc/i386/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:3c6fed2c0701ea0cb430235ff79e3d1115fa522183f6f398c6433c6c925f0fb8"
+		]
+	},
+	"architecture": "386",
+	"os": "linux"
+}

--- a/latest-1/uclibc/i386/image-manifest.json
+++ b/latest-1/uclibc/i386/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:97971c526268d5a742dd179bc514020f97b9ecee36429c1026085ecadac02a16",
+		"size": 392
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:be09a6572b38da0aaed7ccbe3367d7f1d4dcd9e1c9df00c26f3d291c0455a3c7",
+			"size": 718672
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-uclibc"
+	}
+}

--- a/latest-1/uclibc/i386/index.json
+++ b/latest-1/uclibc/i386/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:b303ecb91a5873ec6c0af907fc3828929d68f80b9394f06c2ce51eff1b4d356d",
+			"size": 610,
+			"platform": {
+				"architecture": "386",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-uclibc",
+				"io.containerd.image.name": "busybox:1.35.0-uclibc"
+			}
+		}
+	]
+}

--- a/latest-1/uclibc/i386/oci-layout
+++ b/latest-1/uclibc/i386/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest-1/uclibc/mips64le/blobs/sha256/2c8059e4a59bdbca443286b089d5e12e4933de22278bf25095ed8610892bb863
+++ b/latest-1/uclibc/mips64le/blobs/sha256/2c8059e4a59bdbca443286b089d5e12e4933de22278bf25095ed8610892bb863
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest-1/uclibc/mips64le/blobs/sha256/6bec3ab929b6ce9fd0f9128cfae9a2190c7e094102488b7f34cfffa80e2e44cc
+++ b/latest-1/uclibc/mips64le/blobs/sha256/6bec3ab929b6ce9fd0f9128cfae9a2190c7e094102488b7f34cfffa80e2e44cc
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest-1/uclibc/mips64le/blobs/sha256/c4b3dd53233406d5fe45807a5a057343e53001147aa5ab2669c4400cee324242
+++ b/latest-1/uclibc/mips64le/blobs/sha256/c4b3dd53233406d5fe45807a5a057343e53001147aa5ab2669c4400cee324242
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest-1/uclibc/mips64le/image-config.json
+++ b/latest-1/uclibc/mips64le/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2021-12-26T16:56:57Z",
+	"history": [
+		{
+			"created": "2021-12-26T16:56:57Z",
+			"created_by": "BusyBox 1.35.0 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:6ef9462c52a6b4667581d7605a655a825a26190edd85b73e16381d5ea1772af0"
+		]
+	},
+	"architecture": "mips64le",
+	"os": "linux"
+}

--- a/latest-1/uclibc/mips64le/image-manifest.json
+++ b/latest-1/uclibc/mips64le/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:c4b3dd53233406d5fe45807a5a057343e53001147aa5ab2669c4400cee324242",
+		"size": 397
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:6bec3ab929b6ce9fd0f9128cfae9a2190c7e094102488b7f34cfffa80e2e44cc",
+			"size": 944244
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.35.0-uclibc"
+	}
+}

--- a/latest-1/uclibc/mips64le/index.json
+++ b/latest-1/uclibc/mips64le/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:2c8059e4a59bdbca443286b089d5e12e4933de22278bf25095ed8610892bb863",
+			"size": 610,
+			"platform": {
+				"architecture": "mips64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.35.0-uclibc",
+				"io.containerd.image.name": "busybox:1.35.0-uclibc"
+			}
+		}
+	]
+}

--- a/latest-1/uclibc/mips64le/oci-layout
+++ b/latest-1/uclibc/mips64le/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/glibc/arm32v5/blobs/sha256/491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0
+++ b/latest/glibc/arm32v5/blobs/sha256/491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/glibc/arm32v5/blobs/sha256/d6578b94d614adfa46696754ab33bdd8b8b70ac8adea2fb6061d90e2b01f90e3
+++ b/latest/glibc/arm32v5/blobs/sha256/d6578b94d614adfa46696754ab33bdd8b8b70ac8adea2fb6061d90e2b01f90e3
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/glibc/arm32v5/blobs/sha256/e209cc4af23c3ed4ac3e8cf58f8e9ea90d51fe28fcfca3ad91d91e74aabca274
+++ b/latest/glibc/arm32v5/blobs/sha256/e209cc4af23c3ed4ac3e8cf58f8e9ea90d51fe28fcfca3ad91d91e74aabca274
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/glibc/arm32v5/image-config.json
+++ b/latest/glibc/arm32v5/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:6959386078f1742fa00fdebda2d8e050cc99834f4e0412ad541ba23eac427d05"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v5"
+}

--- a/latest/glibc/arm32v5/image-manifest.json
+++ b/latest/glibc/arm32v5/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:d6578b94d614adfa46696754ab33bdd8b8b70ac8adea2fb6061d90e2b01f90e3",
+		"size": 388
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:e209cc4af23c3ed4ac3e8cf58f8e9ea90d51fe28fcfca3ad91d91e74aabca274",
+			"size": 1776853
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-glibc"
+	}
+}

--- a/latest/glibc/arm32v5/index.json
+++ b/latest/glibc/arm32v5/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:491e28080f41a345b794a1528e23525f67f8693d8c541b9ef8f4990f6af501f0",
+			"size": 610,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v5"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-glibc",
+				"io.containerd.image.name": "busybox:1.36.1-glibc"
+			}
+		}
+	]
+}

--- a/latest/glibc/arm32v5/oci-layout
+++ b/latest/glibc/arm32v5/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/glibc/arm32v7/blobs/sha256/8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc
+++ b/latest/glibc/arm32v7/blobs/sha256/8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/glibc/arm32v7/blobs/sha256/9903cc888814e8feef24381cdb6d29d8598385dcb109a9908a4a98e1ab021532
+++ b/latest/glibc/arm32v7/blobs/sha256/9903cc888814e8feef24381cdb6d29d8598385dcb109a9908a4a98e1ab021532
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/glibc/arm32v7/blobs/sha256/a7cbd68a76a020b8b283c940bc267cd88a66013dcb160cad746344483dfc4b52
+++ b/latest/glibc/arm32v7/blobs/sha256/a7cbd68a76a020b8b283c940bc267cd88a66013dcb160cad746344483dfc4b52
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/glibc/arm32v7/image-config.json
+++ b/latest/glibc/arm32v7/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:f102f3de6a6160248ca4e9d65042808dc19470f59472115d6964724217978bf1"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v7"
+}

--- a/latest/glibc/arm32v7/image-manifest.json
+++ b/latest/glibc/arm32v7/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:9903cc888814e8feef24381cdb6d29d8598385dcb109a9908a4a98e1ab021532",
+		"size": 388
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:a7cbd68a76a020b8b283c940bc267cd88a66013dcb160cad746344483dfc4b52",
+			"size": 1554425
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-glibc"
+	}
+}

--- a/latest/glibc/arm32v7/index.json
+++ b/latest/glibc/arm32v7/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:8a4415fb43600953cbdac6ec03c2d96d900bb21f8d78964837dad7f73b9afcdc",
+			"size": 610,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v7"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-glibc",
+				"io.containerd.image.name": "busybox:1.36.1-glibc"
+			}
+		}
+	]
+}

--- a/latest/glibc/arm32v7/oci-layout
+++ b/latest/glibc/arm32v7/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/glibc/arm64v8/blobs/sha256/15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07
+++ b/latest/glibc/arm64v8/blobs/sha256/15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/glibc/arm64v8/blobs/sha256/45d8eb5967de4c266a4cee23081b4e3855f4f8690f8b9165f804d19278bdeb5e
+++ b/latest/glibc/arm64v8/blobs/sha256/45d8eb5967de4c266a4cee23081b4e3855f4f8690f8b9165f804d19278bdeb5e
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/glibc/arm64v8/blobs/sha256/46bd05c4a04f3d121198e054da02daed22d0f561764acb0f0594066d5972619b
+++ b/latest/glibc/arm64v8/blobs/sha256/46bd05c4a04f3d121198e054da02daed22d0f561764acb0f0594066d5972619b
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/glibc/arm64v8/image-config.json
+++ b/latest/glibc/arm64v8/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:3c4bc35c677d052e8ce865edea845689bf92fe12482683243d74f93fb690b893"
+		]
+	},
+	"architecture": "arm64",
+	"os": "linux",
+	"variant": "v8"
+}

--- a/latest/glibc/arm64v8/image-manifest.json
+++ b/latest/glibc/arm64v8/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:46bd05c4a04f3d121198e054da02daed22d0f561764acb0f0594066d5972619b",
+		"size": 390
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:45d8eb5967de4c266a4cee23081b4e3855f4f8690f8b9165f804d19278bdeb5e",
+			"size": 1840941
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-glibc"
+	}
+}

--- a/latest/glibc/arm64v8/index.json
+++ b/latest/glibc/arm64v8/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:15b3852228f2a4251fb997ce32a52204b76babcaae22df16cac5e217d95a5c07",
+			"size": 610,
+			"platform": {
+				"architecture": "arm64",
+				"os": "linux",
+				"variant": "v8"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-glibc",
+				"io.containerd.image.name": "busybox:1.36.1-glibc"
+			}
+		}
+	]
+}

--- a/latest/glibc/arm64v8/oci-layout
+++ b/latest/glibc/arm64v8/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/glibc/i386/blobs/sha256/1b9198733c40c5c4639f0aa16833bf83263c8545f719181fe02a0c4a09e69861
+++ b/latest/glibc/i386/blobs/sha256/1b9198733c40c5c4639f0aa16833bf83263c8545f719181fe02a0c4a09e69861
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/glibc/i386/blobs/sha256/66516612fa4017d10d02698a124f8cba5aba19a4da03f101c892e033d4f752d7
+++ b/latest/glibc/i386/blobs/sha256/66516612fa4017d10d02698a124f8cba5aba19a4da03f101c892e033d4f752d7
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/glibc/i386/blobs/sha256/b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9
+++ b/latest/glibc/i386/blobs/sha256/b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/glibc/i386/image-config.json
+++ b/latest/glibc/i386/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:8acb69a36cc0b5d75811b48315e24021ec3b0ffda2f00c50438e609ad9e9d628"
+		]
+	},
+	"architecture": "386",
+	"os": "linux"
+}

--- a/latest/glibc/i386/image-manifest.json
+++ b/latest/glibc/i386/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:1b9198733c40c5c4639f0aa16833bf83263c8545f719181fe02a0c4a09e69861",
+		"size": 370
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:66516612fa4017d10d02698a124f8cba5aba19a4da03f101c892e033d4f752d7",
+			"size": 2206391
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-glibc"
+	}
+}

--- a/latest/glibc/i386/index.json
+++ b/latest/glibc/i386/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:b67a20380506da97caef06b5c957d548fe854443c773b0e3d0e21313190beec9",
+			"size": 610,
+			"platform": {
+				"architecture": "386",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-glibc",
+				"io.containerd.image.name": "busybox:1.36.1-glibc"
+			}
+		}
+	]
+}

--- a/latest/glibc/i386/oci-layout
+++ b/latest/glibc/i386/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/glibc/mips64le/blobs/sha256/37c67790aa14859c61c94e0b7e727a8c50a5e246783c252e080ae41187e8ec52
+++ b/latest/glibc/mips64le/blobs/sha256/37c67790aa14859c61c94e0b7e727a8c50a5e246783c252e080ae41187e8ec52
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/glibc/mips64le/blobs/sha256/8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8
+++ b/latest/glibc/mips64le/blobs/sha256/8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/glibc/mips64le/blobs/sha256/b9f2f1866e3467e8735b90ecad932b7c1f122f80426b5beda6fb8a4c87f45757
+++ b/latest/glibc/mips64le/blobs/sha256/b9f2f1866e3467e8735b90ecad932b7c1f122f80426b5beda6fb8a4c87f45757
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/glibc/mips64le/image-config.json
+++ b/latest/glibc/mips64le/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:f8719851cc12f7f9baa7da1e4fd6bbcb0b60891e02301db8eca8ea4bafd62c7a"
+		]
+	},
+	"architecture": "mips64le",
+	"os": "linux"
+}

--- a/latest/glibc/mips64le/image-manifest.json
+++ b/latest/glibc/mips64le/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:37c67790aa14859c61c94e0b7e727a8c50a5e246783c252e080ae41187e8ec52",
+		"size": 375
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:b9f2f1866e3467e8735b90ecad932b7c1f122f80426b5beda6fb8a4c87f45757",
+			"size": 2077641
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-glibc"
+	}
+}

--- a/latest/glibc/mips64le/index.json
+++ b/latest/glibc/mips64le/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:8c4284fa9cc28d0b9455f84527de8b58d5d4df00abcd18e47f2f1dc4e89f7ad8",
+			"size": 610,
+			"platform": {
+				"architecture": "mips64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-glibc",
+				"io.containerd.image.name": "busybox:1.36.1-glibc"
+			}
+		}
+	]
+}

--- a/latest/glibc/mips64le/oci-layout
+++ b/latest/glibc/mips64le/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/glibc/ppc64le/blobs/sha256/1694f502e004b9dd8285dcdb224d23795d858a02cb9aedf98059d7e2d455f4f8
+++ b/latest/glibc/ppc64le/blobs/sha256/1694f502e004b9dd8285dcdb224d23795d858a02cb9aedf98059d7e2d455f4f8
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/glibc/ppc64le/blobs/sha256/8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89
+++ b/latest/glibc/ppc64le/blobs/sha256/8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/glibc/ppc64le/blobs/sha256/ecd7daff73c5b348617555cef6ea4f1fa730392cd0af1af44fa74da57fd827ed
+++ b/latest/glibc/ppc64le/blobs/sha256/ecd7daff73c5b348617555cef6ea4f1fa730392cd0af1af44fa74da57fd827ed
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/glibc/ppc64le/image-config.json
+++ b/latest/glibc/ppc64le/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:2d45ea67d3196f5dc03d93f8df0ae9d21bf02f7d41eb25a594252188f16593f4"
+		]
+	},
+	"architecture": "ppc64le",
+	"os": "linux"
+}

--- a/latest/glibc/ppc64le/image-manifest.json
+++ b/latest/glibc/ppc64le/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:1694f502e004b9dd8285dcdb224d23795d858a02cb9aedf98059d7e2d455f4f8",
+		"size": 374
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:ecd7daff73c5b348617555cef6ea4f1fa730392cd0af1af44fa74da57fd827ed",
+			"size": 2461325
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-glibc"
+	}
+}

--- a/latest/glibc/ppc64le/index.json
+++ b/latest/glibc/ppc64le/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:8513fa0ed4eb7940d8f33995812415caaa21d6fbd4403188941307609f9b6a89",
+			"size": 610,
+			"platform": {
+				"architecture": "ppc64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-glibc",
+				"io.containerd.image.name": "busybox:1.36.1-glibc"
+			}
+		}
+	]
+}

--- a/latest/glibc/ppc64le/oci-layout
+++ b/latest/glibc/ppc64le/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/glibc/s390x/blobs/sha256/4281ce5538f9478db9f20a75015ef2a1ce7dfb42266cab4896663cadd437307b
+++ b/latest/glibc/s390x/blobs/sha256/4281ce5538f9478db9f20a75015ef2a1ce7dfb42266cab4896663cadd437307b
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/glibc/s390x/blobs/sha256/6fed366a7bcbacc0ef09ca2d17065e5859d416094acae6bfeea186d67c37b208
+++ b/latest/glibc/s390x/blobs/sha256/6fed366a7bcbacc0ef09ca2d17065e5859d416094acae6bfeea186d67c37b208
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/glibc/s390x/blobs/sha256/fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6
+++ b/latest/glibc/s390x/blobs/sha256/fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/glibc/s390x/image-config.json
+++ b/latest/glibc/s390x/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (glibc), Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:a55fc97d1858ede2ed634873e9727eb6c09f0407e6cfc2c075b8f9402b81a8ff"
+		]
+	},
+	"architecture": "s390x",
+	"os": "linux"
+}

--- a/latest/glibc/s390x/image-manifest.json
+++ b/latest/glibc/s390x/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:6fed366a7bcbacc0ef09ca2d17065e5859d416094acae6bfeea186d67c37b208",
+		"size": 372
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:4281ce5538f9478db9f20a75015ef2a1ce7dfb42266cab4896663cadd437307b",
+			"size": 1881287
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-glibc"
+	}
+}

--- a/latest/glibc/s390x/index.json
+++ b/latest/glibc/s390x/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:fc1544716c7f86fe4d2e5729ed5341a2cc29370632e0b303312209e5bcc57ed6",
+			"size": 610,
+			"platform": {
+				"architecture": "s390x",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-glibc",
+				"io.containerd.image.name": "busybox:1.36.1-glibc"
+			}
+		}
+	]
+}

--- a/latest/glibc/s390x/oci-layout
+++ b/latest/glibc/s390x/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/musl/arm32v6/blobs/sha256/0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a
+++ b/latest/musl/arm32v6/blobs/sha256/0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/musl/arm32v6/blobs/sha256/7d205c11c6dd2dcafdc8f38f12db83ff61d6165cd69095f2918d31f1b587f8d5
+++ b/latest/musl/arm32v6/blobs/sha256/7d205c11c6dd2dcafdc8f38f12db83ff61d6165cd69095f2918d31f1b587f8d5
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/musl/arm32v6/blobs/sha256/d7e1102586fb0e4048aa13fa2b2dec0d046b4d252daf534b4465c028bec14698
+++ b/latest/musl/arm32v6/blobs/sha256/d7e1102586fb0e4048aa13fa2b2dec0d046b4d252daf534b4465c028bec14698
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/musl/arm32v6/image-config.json
+++ b/latest/musl/arm32v6/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:ba55506e21137ed2a86b28d4fa53274a03646de374abf00782e8510dcb8eacc1"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v6"
+}

--- a/latest/musl/arm32v6/image-manifest.json
+++ b/latest/musl/arm32v6/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:7d205c11c6dd2dcafdc8f38f12db83ff61d6165cd69095f2918d31f1b587f8d5",
+		"size": 391
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:d7e1102586fb0e4048aa13fa2b2dec0d046b4d252daf534b4465c028bec14698",
+			"size": 948846
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-musl"
+	}
+}

--- a/latest/musl/arm32v6/index.json
+++ b/latest/musl/arm32v6/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:0bcc1b827b855c65eaf6e031e894e682b6170160b8a676e1df7527a19d51fb1a",
+			"size": 608,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v6"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-musl",
+				"io.containerd.image.name": "busybox:1.36.1-musl"
+			}
+		}
+	]
+}

--- a/latest/musl/arm32v6/oci-layout
+++ b/latest/musl/arm32v6/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/musl/arm32v7/blobs/sha256/83dc776fdc81b19e8a0c134d8eecfc7793d00ca52c1cc4292e973750e3684712
+++ b/latest/musl/arm32v7/blobs/sha256/83dc776fdc81b19e8a0c134d8eecfc7793d00ca52c1cc4292e973750e3684712
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/musl/arm32v7/blobs/sha256/855943b02ba3319e1345d803a557c4a88bfd0c18954db6869f2ac791e17c4ae3
+++ b/latest/musl/arm32v7/blobs/sha256/855943b02ba3319e1345d803a557c4a88bfd0c18954db6869f2ac791e17c4ae3
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/musl/arm32v7/blobs/sha256/f2939eb0b529af5706172c10db02a0894949c461b81ed4282ff4df5bf18c14d0
+++ b/latest/musl/arm32v7/blobs/sha256/f2939eb0b529af5706172c10db02a0894949c461b81ed4282ff4df5bf18c14d0
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/musl/arm32v7/image-config.json
+++ b/latest/musl/arm32v7/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:f8dbf9ed9afb610b7f5f0e0e3f77dfdd8defaf5192eab3ad7b980c353ae06735"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v7"
+}

--- a/latest/musl/arm32v7/image-manifest.json
+++ b/latest/musl/arm32v7/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:855943b02ba3319e1345d803a557c4a88bfd0c18954db6869f2ac791e17c4ae3",
+		"size": 391
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:83dc776fdc81b19e8a0c134d8eecfc7793d00ca52c1cc4292e973750e3684712",
+			"size": 843648
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-musl"
+	}
+}

--- a/latest/musl/arm32v7/index.json
+++ b/latest/musl/arm32v7/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:f2939eb0b529af5706172c10db02a0894949c461b81ed4282ff4df5bf18c14d0",
+			"size": 608,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v7"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-musl",
+				"io.containerd.image.name": "busybox:1.36.1-musl"
+			}
+		}
+	]
+}

--- a/latest/musl/arm32v7/oci-layout
+++ b/latest/musl/arm32v7/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/musl/arm64v8/blobs/sha256/181aea4c42f8873b483fd576cfa3dacadb70d642c67888825ef2d351d18fa0fc
+++ b/latest/musl/arm64v8/blobs/sha256/181aea4c42f8873b483fd576cfa3dacadb70d642c67888825ef2d351d18fa0fc
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/musl/arm64v8/blobs/sha256/5fe55161a78a4987bee3ddec858b7ca09929f69b8c00ed318d5df93f3769d02c
+++ b/latest/musl/arm64v8/blobs/sha256/5fe55161a78a4987bee3ddec858b7ca09929f69b8c00ed318d5df93f3769d02c
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/musl/arm64v8/blobs/sha256/648143a312f16e5b5a6f64dfa4024a281fb4a30467500ca8b0091a9984f1c751
+++ b/latest/musl/arm64v8/blobs/sha256/648143a312f16e5b5a6f64dfa4024a281fb4a30467500ca8b0091a9984f1c751
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/musl/arm64v8/image-config.json
+++ b/latest/musl/arm64v8/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:f614626d3575823855cc4b7cabf41a1fa314e74a7d1e9e2e4c8bc3b86060b80c"
+		]
+	},
+	"architecture": "arm64",
+	"os": "linux",
+	"variant": "v8"
+}

--- a/latest/musl/arm64v8/image-manifest.json
+++ b/latest/musl/arm64v8/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:5fe55161a78a4987bee3ddec858b7ca09929f69b8c00ed318d5df93f3769d02c",
+		"size": 393
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:181aea4c42f8873b483fd576cfa3dacadb70d642c67888825ef2d351d18fa0fc",
+			"size": 889254
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-musl"
+	}
+}

--- a/latest/musl/arm64v8/index.json
+++ b/latest/musl/arm64v8/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:648143a312f16e5b5a6f64dfa4024a281fb4a30467500ca8b0091a9984f1c751",
+			"size": 608,
+			"platform": {
+				"architecture": "arm64",
+				"os": "linux",
+				"variant": "v8"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-musl",
+				"io.containerd.image.name": "busybox:1.36.1-musl"
+			}
+		}
+	]
+}

--- a/latest/musl/arm64v8/oci-layout
+++ b/latest/musl/arm64v8/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/musl/i386/blobs/sha256/65722cb5d14f1e7b8ed041ff48f4fa2eca5472df4b5fc6927c7590ccc21e126e
+++ b/latest/musl/i386/blobs/sha256/65722cb5d14f1e7b8ed041ff48f4fa2eca5472df4b5fc6927c7590ccc21e126e
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/musl/i386/blobs/sha256/9820f2dc12be11390dfbff4e5bd2b99f5e963ccb16e75085a47235fd9e8da9af
+++ b/latest/musl/i386/blobs/sha256/9820f2dc12be11390dfbff4e5bd2b99f5e963ccb16e75085a47235fd9e8da9af
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/musl/i386/blobs/sha256/a140002cbc95940875c907e7cb88b5f564be044496a65dac93e592579105e819
+++ b/latest/musl/i386/blobs/sha256/a140002cbc95940875c907e7cb88b5f564be044496a65dac93e592579105e819
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/musl/i386/image-config.json
+++ b/latest/musl/i386/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:3e48f29af83a05396a4c510f077340731e4fe5341722821d77a386b52c04817f"
+		]
+	},
+	"architecture": "386",
+	"os": "linux"
+}

--- a/latest/musl/i386/image-manifest.json
+++ b/latest/musl/i386/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:65722cb5d14f1e7b8ed041ff48f4fa2eca5472df4b5fc6927c7590ccc21e126e",
+		"size": 373
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:a140002cbc95940875c907e7cb88b5f564be044496a65dac93e592579105e819",
+			"size": 850353
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-musl"
+	}
+}

--- a/latest/musl/i386/index.json
+++ b/latest/musl/i386/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:9820f2dc12be11390dfbff4e5bd2b99f5e963ccb16e75085a47235fd9e8da9af",
+			"size": 608,
+			"platform": {
+				"architecture": "386",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-musl",
+				"io.containerd.image.name": "busybox:1.36.1-musl"
+			}
+		}
+	]
+}

--- a/latest/musl/i386/oci-layout
+++ b/latest/musl/i386/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/musl/ppc64le/blobs/sha256/88416441befa2b06d32ee1a179f57d57ec34dc21e063d3f7ce56a99e3b3ec053
+++ b/latest/musl/ppc64le/blobs/sha256/88416441befa2b06d32ee1a179f57d57ec34dc21e063d3f7ce56a99e3b3ec053
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/musl/ppc64le/blobs/sha256/be62c3a49c352dd418e4eda2fd00255abf537b538416c738cd0412774569c644
+++ b/latest/musl/ppc64le/blobs/sha256/be62c3a49c352dd418e4eda2fd00255abf537b538416c738cd0412774569c644
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/musl/ppc64le/blobs/sha256/f1916cad6e47b96258ff098ff209e26f3c1c0812aff2ed598e46829507a6e27e
+++ b/latest/musl/ppc64le/blobs/sha256/f1916cad6e47b96258ff098ff209e26f3c1c0812aff2ed598e46829507a6e27e
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/musl/ppc64le/image-config.json
+++ b/latest/musl/ppc64le/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:98cba77cc90f7126a8b49b7ebd658e239f93a56df2d37cd6427eaadd795446d7"
+		]
+	},
+	"architecture": "ppc64le",
+	"os": "linux"
+}

--- a/latest/musl/ppc64le/image-manifest.json
+++ b/latest/musl/ppc64le/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:be62c3a49c352dd418e4eda2fd00255abf537b538416c738cd0412774569c644",
+		"size": 377
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:f1916cad6e47b96258ff098ff209e26f3c1c0812aff2ed598e46829507a6e27e",
+			"size": 941070
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-musl"
+	}
+}

--- a/latest/musl/ppc64le/index.json
+++ b/latest/musl/ppc64le/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:88416441befa2b06d32ee1a179f57d57ec34dc21e063d3f7ce56a99e3b3ec053",
+			"size": 608,
+			"platform": {
+				"architecture": "ppc64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-musl",
+				"io.containerd.image.name": "busybox:1.36.1-musl"
+			}
+		}
+	]
+}

--- a/latest/musl/ppc64le/oci-layout
+++ b/latest/musl/ppc64le/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/musl/s390x/blobs/sha256/2b020b4fcb46e2ece9ccc96012d7ccad80689ff25a25a0688b31cf4e18b2978f
+++ b/latest/musl/s390x/blobs/sha256/2b020b4fcb46e2ece9ccc96012d7ccad80689ff25a25a0688b31cf4e18b2978f
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/musl/s390x/blobs/sha256/586b0245c50baca0c19d75cfa317a2ec43997791cf7d5f29c99bda7b7ebcdb8b
+++ b/latest/musl/s390x/blobs/sha256/586b0245c50baca0c19d75cfa317a2ec43997791cf7d5f29c99bda7b7ebcdb8b
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/musl/s390x/blobs/sha256/d791415167d4c090869f79a02622437901217be5cbb2177a80dc2e62d0d3718a
+++ b/latest/musl/s390x/blobs/sha256/d791415167d4c090869f79a02622437901217be5cbb2177a80dc2e62d0d3718a
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/musl/s390x/image-config.json
+++ b/latest/musl/s390x/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (musl), Alpine 3.19.1"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:55c4feb4dbb5f80925da4c8e71e775933a56ecda19cf6d091ee67f20474f8aa0"
+		]
+	},
+	"architecture": "s390x",
+	"os": "linux"
+}

--- a/latest/musl/s390x/image-manifest.json
+++ b/latest/musl/s390x/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:2b020b4fcb46e2ece9ccc96012d7ccad80689ff25a25a0688b31cf4e18b2978f",
+		"size": 375
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:586b0245c50baca0c19d75cfa317a2ec43997791cf7d5f29c99bda7b7ebcdb8b",
+			"size": 920666
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-musl"
+	}
+}

--- a/latest/musl/s390x/index.json
+++ b/latest/musl/s390x/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:d791415167d4c090869f79a02622437901217be5cbb2177a80dc2e62d0d3718a",
+			"size": 608,
+			"platform": {
+				"architecture": "s390x",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-musl",
+				"io.containerd.image.name": "busybox:1.36.1-musl"
+			}
+		}
+	]
+}

--- a/latest/musl/s390x/oci-layout
+++ b/latest/musl/s390x/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/uclibc/arm32v5/blobs/sha256/120231968b7db68bb2d25cd765a3eee8fe0ec5be354a4306354fdd9606bd7774
+++ b/latest/uclibc/arm32v5/blobs/sha256/120231968b7db68bb2d25cd765a3eee8fe0ec5be354a4306354fdd9606bd7774
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/uclibc/arm32v5/blobs/sha256/2e2d13aea845763e5152bb8116738d5179f67b79fc6fde83bf813896829d4bf3
+++ b/latest/uclibc/arm32v5/blobs/sha256/2e2d13aea845763e5152bb8116738d5179f67b79fc6fde83bf813896829d4bf3
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/uclibc/arm32v5/blobs/sha256/9be06eb6ec3aaf1ca11f443876561f4e75e1dd0ceb407c1880033d7ff6328b3e
+++ b/latest/uclibc/arm32v5/blobs/sha256/9be06eb6ec3aaf1ca11f443876561f4e75e1dd0ceb407c1880033d7ff6328b3e
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/uclibc/arm32v5/image-config.json
+++ b/latest/uclibc/arm32v5/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:aba6a4adec617b4cd5f736cd4f60d980a26274e051339f2531308b365cecd898"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v5"
+}

--- a/latest/uclibc/arm32v5/image-manifest.json
+++ b/latest/uclibc/arm32v5/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:9be06eb6ec3aaf1ca11f443876561f4e75e1dd0ceb407c1880033d7ff6328b3e",
+		"size": 410
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:120231968b7db68bb2d25cd765a3eee8fe0ec5be354a4306354fdd9606bd7774",
+			"size": 744233
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-uclibc"
+	}
+}

--- a/latest/uclibc/arm32v5/index.json
+++ b/latest/uclibc/arm32v5/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:2e2d13aea845763e5152bb8116738d5179f67b79fc6fde83bf813896829d4bf3",
+			"size": 610,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v5"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-uclibc",
+				"io.containerd.image.name": "busybox:1.36.1-uclibc"
+			}
+		}
+	]
+}

--- a/latest/uclibc/arm32v5/oci-layout
+++ b/latest/uclibc/arm32v5/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/uclibc/arm32v7/blobs/sha256/19210f7552436b95fa7de660fcbf9e9425a0813bfccb850b3fcd053709caf443
+++ b/latest/uclibc/arm32v7/blobs/sha256/19210f7552436b95fa7de660fcbf9e9425a0813bfccb850b3fcd053709caf443
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/uclibc/arm32v7/blobs/sha256/b87edd76d8d0b9e848a0059a3014d87dabf763bc6cfcb9df52d13f4523a3d371
+++ b/latest/uclibc/arm32v7/blobs/sha256/b87edd76d8d0b9e848a0059a3014d87dabf763bc6cfcb9df52d13f4523a3d371
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/uclibc/arm32v7/blobs/sha256/c2858fb01eb20e8b8f27c5d3108e9df3065a5c3196a170111aabbf09b81d4bf9
+++ b/latest/uclibc/arm32v7/blobs/sha256/c2858fb01eb20e8b8f27c5d3108e9df3065a5c3196a170111aabbf09b81d4bf9
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/uclibc/arm32v7/image-config.json
+++ b/latest/uclibc/arm32v7/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:aa0968c5de9a04f858277e34f03010cec8c088c110f50f1c642535461cba1a25"
+		]
+	},
+	"architecture": "arm",
+	"os": "linux",
+	"variant": "v7"
+}

--- a/latest/uclibc/arm32v7/image-manifest.json
+++ b/latest/uclibc/arm32v7/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:c2858fb01eb20e8b8f27c5d3108e9df3065a5c3196a170111aabbf09b81d4bf9",
+		"size": 410
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:19210f7552436b95fa7de660fcbf9e9425a0813bfccb850b3fcd053709caf443",
+			"size": 708929
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-uclibc"
+	}
+}

--- a/latest/uclibc/arm32v7/index.json
+++ b/latest/uclibc/arm32v7/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:b87edd76d8d0b9e848a0059a3014d87dabf763bc6cfcb9df52d13f4523a3d371",
+			"size": 610,
+			"platform": {
+				"architecture": "arm",
+				"os": "linux",
+				"variant": "v7"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-uclibc",
+				"io.containerd.image.name": "busybox:1.36.1-uclibc"
+			}
+		}
+	]
+}

--- a/latest/uclibc/arm32v7/oci-layout
+++ b/latest/uclibc/arm32v7/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/uclibc/arm64v8/blobs/sha256/3455187e2f1e65df5f0afefed60392966d2778c19c7294c9e23138f710aa4123
+++ b/latest/uclibc/arm64v8/blobs/sha256/3455187e2f1e65df5f0afefed60392966d2778c19c7294c9e23138f710aa4123
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/uclibc/arm64v8/blobs/sha256/7f8fa07ac90d44a4aa221085baaa1b20cc6c0562cd3d9841061a6e9aac68b538
+++ b/latest/uclibc/arm64v8/blobs/sha256/7f8fa07ac90d44a4aa221085baaa1b20cc6c0562cd3d9841061a6e9aac68b538
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/uclibc/arm64v8/blobs/sha256/e1debaf3414bc4cc8e5074c1a5ccf993b687481f26303a8b96e1530b06fa2161
+++ b/latest/uclibc/arm64v8/blobs/sha256/e1debaf3414bc4cc8e5074c1a5ccf993b687481f26303a8b96e1530b06fa2161
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/uclibc/arm64v8/image-config.json
+++ b/latest/uclibc/arm64v8/image-config.json
@@ -1,0 +1,23 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:018615f7b68c74fa3d4ab6fc2d3dcfa4effbcec0a9ece1a84dfc60ab22428e92"
+		]
+	},
+	"architecture": "arm64",
+	"os": "linux",
+	"variant": "v8"
+}

--- a/latest/uclibc/arm64v8/image-manifest.json
+++ b/latest/uclibc/arm64v8/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:3455187e2f1e65df5f0afefed60392966d2778c19c7294c9e23138f710aa4123",
+		"size": 412
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:e1debaf3414bc4cc8e5074c1a5ccf993b687481f26303a8b96e1530b06fa2161",
+			"size": 804264
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-uclibc"
+	}
+}

--- a/latest/uclibc/arm64v8/index.json
+++ b/latest/uclibc/arm64v8/index.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:7f8fa07ac90d44a4aa221085baaa1b20cc6c0562cd3d9841061a6e9aac68b538",
+			"size": 610,
+			"platform": {
+				"architecture": "arm64",
+				"os": "linux",
+				"variant": "v8"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-uclibc",
+				"io.containerd.image.name": "busybox:1.36.1-uclibc"
+			}
+		}
+	]
+}

--- a/latest/uclibc/arm64v8/oci-layout
+++ b/latest/uclibc/arm64v8/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/uclibc/i386/blobs/sha256/a59b0fb9e2aaf1e563d29a622d1fa17e016c22df25c0345cf1a5240331791bf5
+++ b/latest/uclibc/i386/blobs/sha256/a59b0fb9e2aaf1e563d29a622d1fa17e016c22df25c0345cf1a5240331791bf5
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/uclibc/i386/blobs/sha256/db081018be5264766a388960b3c2e7e0a3cfb4360329c5f7c2b3b700cd11864b
+++ b/latest/uclibc/i386/blobs/sha256/db081018be5264766a388960b3c2e7e0a3cfb4360329c5f7c2b3b700cd11864b
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/uclibc/i386/blobs/sha256/e6eb21d11edb8b30d689d9c6d7c0860cefa4f022f2bb439b3da4a0f39e3a344f
+++ b/latest/uclibc/i386/blobs/sha256/e6eb21d11edb8b30d689d9c6d7c0860cefa4f022f2bb439b3da4a0f39e3a344f
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/uclibc/i386/image-config.json
+++ b/latest/uclibc/i386/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:73d5d8f414a55d30118f65a67bf958511c14fa23905dde4ec6d913ffb4e3101a"
+		]
+	},
+	"architecture": "386",
+	"os": "linux"
+}

--- a/latest/uclibc/i386/image-manifest.json
+++ b/latest/uclibc/i386/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:a59b0fb9e2aaf1e563d29a622d1fa17e016c22df25c0345cf1a5240331791bf5",
+		"size": 392
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:db081018be5264766a388960b3c2e7e0a3cfb4360329c5f7c2b3b700cd11864b",
+			"size": 721523
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-uclibc"
+	}
+}

--- a/latest/uclibc/i386/index.json
+++ b/latest/uclibc/i386/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:e6eb21d11edb8b30d689d9c6d7c0860cefa4f022f2bb439b3da4a0f39e3a344f",
+			"size": 610,
+			"platform": {
+				"architecture": "386",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-uclibc",
+				"io.containerd.image.name": "busybox:1.36.1-uclibc"
+			}
+		}
+	]
+}

--- a/latest/uclibc/i386/oci-layout
+++ b/latest/uclibc/i386/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}

--- a/latest/uclibc/mips64le/blobs/sha256/16b2225af5a2181079c894731b1031c046d90aca99349dd3487cfc6d6702d0e3
+++ b/latest/uclibc/mips64le/blobs/sha256/16b2225af5a2181079c894731b1031c046d90aca99349dd3487cfc6d6702d0e3
@@ -1,0 +1,1 @@
+../../rootfs.tar.gz

--- a/latest/uclibc/mips64le/blobs/sha256/388eed10bf5614e88ae1e2b2c1d237cbef877a07858125415556e3d9edff526d
+++ b/latest/uclibc/mips64le/blobs/sha256/388eed10bf5614e88ae1e2b2c1d237cbef877a07858125415556e3d9edff526d
@@ -1,0 +1,1 @@
+../../image-manifest.json

--- a/latest/uclibc/mips64le/blobs/sha256/cd60f88674723ffdec05a32d2bee1157f95e335ced9c3efea5686b9b15cd1416
+++ b/latest/uclibc/mips64le/blobs/sha256/cd60f88674723ffdec05a32d2bee1157f95e335ced9c3efea5686b9b15cd1416
@@ -1,0 +1,1 @@
+../../image-config.json

--- a/latest/uclibc/mips64le/image-config.json
+++ b/latest/uclibc/mips64le/image-config.json
@@ -1,0 +1,22 @@
+{
+	"config": {
+		"Cmd": [
+			"sh"
+		]
+	},
+	"created": "2023-05-18T22:34:17Z",
+	"history": [
+		{
+			"created": "2023-05-18T22:34:17Z",
+			"created_by": "BusyBox 1.36.1 (uclibc), Buildroot 2023.11.1, Debian 12"
+		}
+	],
+	"rootfs": {
+		"type": "layers",
+		"diff_ids": [
+			"sha256:f0ad144f39de962239b73c3e675012be958ad726df8d61e03fa0d6f1f041e661"
+		]
+	},
+	"architecture": "mips64le",
+	"os": "linux"
+}

--- a/latest/uclibc/mips64le/image-manifest.json
+++ b/latest/uclibc/mips64le/image-manifest.json
@@ -1,0 +1,20 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.manifest.v1+json",
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"digest": "sha256:cd60f88674723ffdec05a32d2bee1157f95e335ced9c3efea5686b9b15cd1416",
+		"size": 397
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"digest": "sha256:16b2225af5a2181079c894731b1031c046d90aca99349dd3487cfc6d6702d0e3",
+			"size": 948864
+		}
+	],
+	"annotations": {
+		"org.opencontainers.image.url": "https://github.com/docker-library/busybox",
+		"org.opencontainers.image.version": "1.36.1-uclibc"
+	}
+}

--- a/latest/uclibc/mips64le/index.json
+++ b/latest/uclibc/mips64le/index.json
@@ -1,0 +1,19 @@
+{
+	"schemaVersion": 2,
+	"mediaType": "application/vnd.oci.image.index.v1+json",
+	"manifests": [
+		{
+			"mediaType": "application/vnd.oci.image.manifest.v1+json",
+			"digest": "sha256:388eed10bf5614e88ae1e2b2c1d237cbef877a07858125415556e3d9edff526d",
+			"size": 610,
+			"platform": {
+				"architecture": "mips64le",
+				"os": "linux"
+			},
+			"annotations": {
+				"org.opencontainers.image.ref.name": "busybox:1.36.1-uclibc",
+				"io.containerd.image.name": "busybox:1.36.1-uclibc"
+			}
+		}
+	]
+}

--- a/latest/uclibc/mips64le/oci-layout
+++ b/latest/uclibc/mips64le/oci-layout
@@ -1,0 +1,1 @@
+{"imageLayoutVersion":"1.0.0"}


### PR DESCRIPTION
This cherry-picks all the metadata commits from the (now successful) assorted `meta-*` branches (as discussed/planned over in #188).

The command I used to generate this branch:

`git branch --list --remotes --format '..%(refname:short)' docker-library/meta-* | grep -v riscv64 | tac | xargs -rt git cherry-pick -x`

Output then looks something like:

```console
$ git branch --list --remotes --format '..%(refname:short)' docker-library/meta-* | grep -v riscv64 | tac | xargs -rt git cherry-pick -x
git cherry-pick -x ..docker-library/meta-s390x ..docker-library/meta-ppc64le ..docker-library/meta-mips64le ..docker-library/meta-i386 ..docker-library/meta-arm64v8 ..docker-library/meta-arm32v7 ..docker-library/meta-arm32v6 ..docker-library/meta-arm32v5 ..docker-library/meta-amd64
[cherry-meta 884455c] Update metadata for arm32v5
...
```

(Assumptions there being that my local "upstream"/"origin" remote is named `docker-library` and I have done a fresh `git fetch -p docker-library` and my local fetch config for the `docker-library` remote includes `fetch = +refs/heads/meta-*:refs/remotes/docker-library/meta-*`)

Notably, I have _not_ included `riscv64` here because I do not actually believe it will stay reproducible over time (due to being based on Debian Unstable + Alpine Edge and having to do hacks to even get it to build successfully right now; see https://github.com/docker-library/busybox/commit/10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa, especially `latest/musl/Dockerfile.builder` / https://github.com/docker-library/oi-janky-groovy/commit/51430233a29d874f424f73cbaeef3f757a102b73).