### PR TITLE
Add `apk upgrade libssl3 libcrypto3` as temporary Alpine Edge woes balm

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -16,6 +16,9 @@ RUN set -eux; \
 # busybox's tar ironically does not maintain mtime of directories correctly (which we need for SOURCE_DATE_EPOCH / reproducibility)
 		tar \
 	;
+
+# https://github.com/alpinelinux/docker-alpine/issues/383
+RUN set -eux; if grep -qF '/edge/' '/etc/apk/repositories'; then apk upgrade --no-cache libssl3 libcrypto3; curl --version; dirmngr --version; fi
 {{ ) else ( -}}
 FROM debian:bookworm-slim
 

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -22,6 +22,9 @@ RUN set -eux; \
 		tar \
 	;
 
+# https://github.com/alpinelinux/docker-alpine/issues/383
+RUN set -eux; if grep -qF '/edge/' '/etc/apk/repositories'; then apk upgrade --no-cache libssl3 libcrypto3; curl --version; dirmngr --version; fi
+
 # pub   1024D/ACC9965B 2006-12-12
 #       Key fingerprint = C9E9 416F 76E6 10DB D09D  040F 47B7 0C55 ACC9 965B
 # uid                  Denis Vlasenko <vda.linux@googlemail.com>

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -22,6 +22,9 @@ RUN set -eux; \
 		tar \
 	;
 
+# https://github.com/alpinelinux/docker-alpine/issues/383
+RUN set -eux; if grep -qF '/edge/' '/etc/apk/repositories'; then apk upgrade --no-cache libssl3 libcrypto3; curl --version; dirmngr --version; fi
+
 # pub   1024D/ACC9965B 2006-12-12
 #       Key fingerprint = C9E9 416F 76E6 10DB D09D  040F 47B7 0C55 ACC9 965B
 # uid                  Denis Vlasenko <vda.linux@googlemail.com>


### PR DESCRIPTION
```console
$ docker run -it --rm --pull=always alpine:edge
edge: Pulling from library/alpine
Digest: sha256:67b8a3c4c19bbdd43de723881bc536758f5e780f8d32ef8f5ef2b72f769a3e78
Status: Image is up to date for alpine:edge
/ # apk add --no-cache --quiet curl
/ # curl --version
Error relocating /usr/lib/libcurl.so.4: SSL_get0_group_name: symbol not found
```

See https://github.com/alpinelinux/docker-alpine/issues/383 (and https://github.com/docker-library/busybox/pull/193)