### PR TITLE
Apply patch to remove CBQ functionality

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -251,6 +251,20 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
+{{ if env.variant == "glibc" then ( -}}
+# https://github.com/docker-library/busybox/issues/198
+# https://bugs.busybox.net/show_bug.cgi?id=15931
+# https://bugs.debian.org/1071648
+RUN set -eux; \
+	. /etc/os-release; \
+	if [ "${ID:-}" = 'debian' ] && [ "${VERSION_CODENAME:-}" != 'bookworm' ]; then \
+		curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
+		echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
+		patch -p1 --input=busybox-no-cbq.patch; \
+		rm busybox-no-cbq.patch; \
+	fi
+
+{{ ) else "" end -}}
 RUN set -eux; \
 	\
 # build date/time gets embedded in the BusyBox binary -- SOURCE_DATE_EPOCH should override that

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -49,6 +49,18 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
+# https://github.com/docker-library/busybox/issues/198
+# https://bugs.busybox.net/show_bug.cgi?id=15931
+# https://bugs.debian.org/1071648
+RUN set -eux; \
+	. /etc/os-release; \
+	if [ "${ID:-}" = 'debian' ] && [ "${VERSION_CODENAME:-}" != 'bookworm' ]; then \
+		curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
+		echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
+		patch -p1 --input=busybox-no-cbq.patch; \
+		rm busybox-no-cbq.patch; \
+	fi
+
 RUN set -eux; \
 	\
 # build date/time gets embedded in the BusyBox binary -- SOURCE_DATE_EPOCH should override that

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -49,6 +49,18 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
+# https://github.com/docker-library/busybox/issues/198
+# https://bugs.busybox.net/show_bug.cgi?id=15931
+# https://bugs.debian.org/1071648
+RUN set -eux; \
+	. /etc/os-release; \
+	if [ "${ID:-}" = 'debian' ] && [ "${VERSION_CODENAME:-}" != 'bookworm' ]; then \
+		curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
+		echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
+		patch -p1 --input=busybox-no-cbq.patch; \
+		rm busybox-no-cbq.patch; \
+	fi
+
 RUN set -eux; \
 	\
 # build date/time gets embedded in the BusyBox binary -- SOURCE_DATE_EPOCH should override that


### PR DESCRIPTION
This allows us to build successfully on Debian Unstable again.

Fixes https://github.com/docker-library/busybox/issues/198