### PR TITLE
Add missing `set -e` to our `nslookup` smoke test 😭

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -465,7 +465,8 @@ RUN set -eux; \
 	[ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too
-RUN cp -L /etc/resolv.conf rootfs/etc/; \
+RUN set -eux; \
+	cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -227,7 +227,8 @@ RUN set -eux; \
 	[ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too
-RUN cp -L /etc/resolv.conf rootfs/etc/; \
+RUN set -eux; \
+	cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -198,7 +198,8 @@ RUN set -eux; \
 	[ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too
-RUN cp -L /etc/resolv.conf rootfs/etc/; \
+RUN set -eux; \
+	cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -357,7 +357,8 @@ RUN set -eux; \
 	[ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too
-RUN cp -L /etc/resolv.conf rootfs/etc/; \
+RUN set -eux; \
+	cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -225,7 +225,8 @@ RUN set -eux; \
 	[ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too
-RUN cp -L /etc/resolv.conf rootfs/etc/; \
+RUN set -eux; \
+	cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -196,7 +196,8 @@ RUN set -eux; \
 	[ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too
-RUN cp -L /etc/resolv.conf rootfs/etc/; \
+RUN set -eux; \
+	cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -355,7 +355,8 @@ RUN set -eux; \
 	[ "$(chroot rootfs date +%Z)" = 'UTC' ]
 
 # test and make sure DNS works too
-RUN cp -L /etc/resolv.conf rootfs/etc/; \
+RUN set -eux; \
+	cp -L /etc/resolv.conf rootfs/etc/; \
 	chroot rootfs /bin/sh -xec 'nslookup google.com'; \
 	rm rootfs/etc/resolv.conf
 


### PR DESCRIPTION
Apparently missing for ~5 years 🤦

This might cause some of our builds to fail which haven't been previously, but I guess they would do so in ways we should investigate. :see_no_evil: