### PR TITLE
Add explicit "patches" directory

### DIFF
--- a/.patches/README.md
+++ b/.patches/README.md
@@ -1,0 +1,5 @@
+# BusyBox Patches
+
+This directory contains patches we apply during our various builds of BusyBox.  They are not necessarily *all* applied to all builds, but they are intended to be as minimal as possible, focused primarily on compilation or correctness issues, such that we still represent upstream's releases accurately.
+
+Metadata in each patch should be following [Debian's "DEP-3" Patch Tagging Guidelines](https://dep-team.pages.debian.net/deps/dep3/) to ensure we track appropriate provenance (and that they were submitted upstream in some form, or that we're explicitly tracking our justification for *why* we didn't do so).

--- a/.patches/no-cbq.patch
+++ b/.patches/no-cbq.patch
@@ -1,0 +1,161 @@
+Description: remove CBQ functionality
+Author: Tianon Gravi <tianon@debian.org>
+Origin: https://bugs.busybox.net/attachment.cgi?id=9751&action=edit
+
+See:
+- https://github.com/docker-library/busybox/issues/198
+- https://bugs.busybox.net/show_bug.cgi?id=15931
+- https://bugs.debian.org/1071648
+
+See also:
+- https://github.com/torvalds/linux/commit/33241dca486264193ed68167c8eeae1fb197f3df
+- https://github.com/iproute2/iproute2/commit/07ba0af3fee132eddc1c2eab643ff4910181c993
+
+diff --git a/networking/tc.c b/networking/tc.c
+index 3a79fd2d9..753efb9ff 100644
+--- a/networking/tc.c
++++ b/networking/tc.c
+@@ -31,7 +31,7 @@
+ //usage:	"qdisc [handle QHANDLE] [root|"IF_FEATURE_TC_INGRESS("ingress|")"parent CLASSID]\n"
+ /* //usage: "[estimator INTERVAL TIME_CONSTANT]\n" */
+ //usage:	"	[[QDISC_KIND] [help|OPTIONS]]\n"
+-//usage:	"	QDISC_KIND := [p|b]fifo|tbf|prio|cbq|red|etc.\n"
++//usage:	"	QDISC_KIND := [p|b]fifo|tbf|prio|red|etc.\n"
+ //usage:	"qdisc show [dev STRING]"IF_FEATURE_TC_INGRESS(" [ingress]")"\n"
+ //usage:	"class [classid CLASSID] [root|parent CLASSID]\n"
+ //usage:	"	[[QDISC_KIND] [help|OPTIONS] ]\n"
+@@ -224,105 +224,6 @@ static int prio_print_opt(struct rtattr *opt)
+ 	return 0;
+ }
+ 
+-#if 0
+-/* Class Based Queue */
+-static int cbq_parse_opt(int argc, char **argv, struct nlmsghdr *n)
+-{
+-	return 0;
+-}
+-#endif
+-static int cbq_print_opt(struct rtattr *opt)
+-{
+-	struct rtattr *tb[TCA_CBQ_MAX+1];
+-	struct tc_ratespec *r = NULL;
+-	struct tc_cbq_lssopt *lss = NULL;
+-	struct tc_cbq_wrropt *wrr = NULL;
+-	struct tc_cbq_fopt *fopt = NULL;
+-	struct tc_cbq_ovl *ovl = NULL;
+-	const char *const error = "CBQ: too short %s opt";
+-	char buf[64];
+-
+-	if (opt == NULL)
+-		goto done;
+-	parse_rtattr_nested(tb, TCA_CBQ_MAX, opt);
+-
+-	if (tb[TCA_CBQ_RATE]) {
+-		if (RTA_PAYLOAD(tb[TCA_CBQ_RATE]) < sizeof(*r))
+-			bb_error_msg(error, "rate");
+-		else
+-			r = RTA_DATA(tb[TCA_CBQ_RATE]);
+-	}
+-	if (tb[TCA_CBQ_LSSOPT]) {
+-		if (RTA_PAYLOAD(tb[TCA_CBQ_LSSOPT]) < sizeof(*lss))
+-			bb_error_msg(error, "lss");
+-		else
+-			lss = RTA_DATA(tb[TCA_CBQ_LSSOPT]);
+-	}
+-	if (tb[TCA_CBQ_WRROPT]) {
+-		if (RTA_PAYLOAD(tb[TCA_CBQ_WRROPT]) < sizeof(*wrr))
+-			bb_error_msg(error, "wrr");
+-		else
+-			wrr = RTA_DATA(tb[TCA_CBQ_WRROPT]);
+-	}
+-	if (tb[TCA_CBQ_FOPT]) {
+-		if (RTA_PAYLOAD(tb[TCA_CBQ_FOPT]) < sizeof(*fopt))
+-			bb_error_msg(error, "fopt");
+-		else
+-			fopt = RTA_DATA(tb[TCA_CBQ_FOPT]);
+-	}
+-	if (tb[TCA_CBQ_OVL_STRATEGY]) {
+-		if (RTA_PAYLOAD(tb[TCA_CBQ_OVL_STRATEGY]) < sizeof(*ovl))
+-			bb_error_msg("CBQ: too short overlimit strategy %u/%u",
+-				(unsigned) RTA_PAYLOAD(tb[TCA_CBQ_OVL_STRATEGY]),
+-				(unsigned) sizeof(*ovl));
+-		else
+-			ovl = RTA_DATA(tb[TCA_CBQ_OVL_STRATEGY]);
+-	}
+-
+-	if (r) {
+-		print_rate(buf, sizeof(buf), r->rate);
+-		printf("rate %s ", buf);
+-		if (show_details) {
+-			printf("cell %ub ", 1<<r->cell_log);
+-			if (r->mpu)
+-				printf("mpu %ub ", r->mpu);
+-			if (r->overhead)
+-				printf("overhead %ub ", r->overhead);
+-		}
+-	}
+-	if (lss && lss->flags) {
+-		bool comma = false;
+-		bb_putchar('(');
+-		if (lss->flags&TCF_CBQ_LSS_BOUNDED) {
+-			printf("bounded");
+-			comma = true;
+-		}
+-		if (lss->flags&TCF_CBQ_LSS_ISOLATED) {
+-			if (comma)
+-				bb_putchar(',');
+-			printf("isolated");
+-		}
+-		printf(") ");
+-	}
+-	if (wrr) {
+-		if (wrr->priority != TC_CBQ_MAXPRIO)
+-			printf("prio %u", wrr->priority);
+-		else
+-			printf("prio no-transmit");
+-		if (show_details) {
+-			printf("/%u ", wrr->cpriority);
+-			if (wrr->weight != 1) {
+-				print_rate(buf, sizeof(buf), wrr->weight);
+-				printf("weight %s ", buf);
+-			}
+-			if (wrr->allot)
+-				printf("allot %ub ", wrr->allot);
+-		}
+-	}
+- done:
+-	return 0;
+-}
+-
+ static FAST_FUNC int print_qdisc(
+ 		const struct sockaddr_nl *who UNUSED_PARAM,
+ 		struct nlmsghdr *hdr,
+@@ -368,12 +269,10 @@ static FAST_FUNC int print_qdisc(
+ 	if (msg->tcm_info != 1)
+ 		printf("refcnt %d ", msg->tcm_info);
+ 	if (tb[TCA_OPTIONS]) {
+-		static const char _q_[] ALIGN1 = "pfifo_fast\0""cbq\0";
++		static const char _q_[] ALIGN1 = "pfifo_fast\0";
+ 		int qqq = index_in_strings(_q_, name);
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			prio_print_opt(tb[TCA_OPTIONS]);
+-		} else if (qqq == 1) { /* class based queuing */
+-			cbq_print_opt(tb[TCA_OPTIONS]);
+ 		} else {
+ 			/* don't know how to print options for this qdisc */
+ 			printf("(options for %s)", name);
+@@ -438,13 +337,10 @@ static FAST_FUNC int print_class(
+ 		printf("leaf %x ", msg->tcm_info >> 16);
+ 	/* Do that get_qdisc_kind(RTA_DATA(tb[TCA_KIND])).  */
+ 	if (tb[TCA_OPTIONS]) {
+-		static const char _q_[] ALIGN1 = "pfifo_fast\0""cbq\0";
++		static const char _q_[] ALIGN1 = "pfifo_fast\0";
+ 		int qqq = index_in_strings(_q_, name);
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			/* nothing. */ /*prio_print_opt(tb[TCA_OPTIONS]);*/
+-		} else if (qqq == 1) { /* class based queuing */
+-			/* cbq_print_copt() is identical to cbq_print_opt(). */
+-			cbq_print_opt(tb[TCA_OPTIONS]);
+ 		} else {
+ 			/* don't know how to print options for this class */
+ 			printf("(options for %s)", name);

--- a/.patches/sha1_process_block64_shaNI.patch
+++ b/.patches/sha1_process_block64_shaNI.patch
@@ -1,0 +1,48 @@
+Description: libbb/sha: add missing sha-NI guard
+Author: André Przywara <andre.przywara@arm.com>
+Date: Tue, 10 Sep 2024 06:33:00 -0700
+Origin: http://lists.busybox.net/pipermail/busybox/2024-September/090899.html
+
+The ENABLE_SHA1_HWACCEL Kconfig symbol is meant to be archicture
+agnostic, so can be enabled regardless of whether your build
+architecture provides hardware acceleration or not. At the moment only
+x86 implements this, so every piece of optimised code should be guarded
+by both ENABLE_SHA1_HWACCEL and (__x86_64__ || __i386__). This is missing
+at one place, so compiling for arm64 breaks when ENABLE_SHA1_HWACCEL is
+enabled:
+================================
+libbb/hash_md5_sha.c: In function ‘sha1_end’:
+libbb/hash_md5_sha.c:1316:28: error: ‘sha1_process_block64_shaNI’ undeclared (first use in this function); did you mean ‘sha1_process_block64’?
+ 1316 |   || ctx->process_block == sha1_process_block64_shaNI
+      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~
+      |                            sha1_process_block64
+libbb/hash_md5_sha.c:1316:28: note: each undeclared identifier is reported only once for each function it appears in
+make[1]: *** [scripts/Makefile.build:197: libbb/hash_md5_sha.o] Error 1
+make: *** [Makefile:744: libbb] Error 2
+================================
+
+Add the missing guards around the call to sha1_process_block64_shaNI to
+fix the build on other architectures with ENABLE_SHA1_HWACCEL enabled.
+
+Change-Id: I40bba388422625f4230abf15a5de23e1fdc654fc
+Signed-off-by: André Przywara <andre.przywara@arm.com>
+---
+ libbb/hash_md5_sha.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libbb/hash_md5_sha.c b/libbb/hash_md5_sha.c
+index 57a801459..75a61c32c 100644
+--- a/libbb/hash_md5_sha.c
++++ b/libbb/hash_md5_sha.c
+@@ -1313,7 +1313,9 @@ unsigned FAST_FUNC sha1_end(sha1_ctx_t *ctx, void *resbuf)
+ 	hash_size = 8;
+ 	if (ctx->process_block == sha1_process_block64
+ #if ENABLE_SHA1_HWACCEL
++# if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
+ 	 || ctx->process_block == sha1_process_block64_shaNI
++# endif
+ #endif
+ 	) {
+ 		hash_size = 5;
+-- 
+2.25.1

--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -251,14 +251,31 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
-# https://github.com/docker-library/busybox/issues/198
-# https://bugs.busybox.net/show_bug.cgi?id=15931
-# https://bugs.debian.org/1071648
+{{
+	(
+		[
+			"no-cbq.patch",
+			if .version | startswith("1.36.") then empty else
+				"sha1_process_block64_shaNI.patch"
+			end,
+			empty # trailing comma
+		]
+		| map("/.patches/" + .)
+	) as $patches
+	| if $patches | length > 0 then (
+-}}
+# apply necessary/minimal patches (see /.patches/ in the top level of the repository)
+COPY \
+{{ $patches | map( -}}
+	{{ . }} \
+{{ ) | join("") -}}
+	./.patches/
 RUN set -eux; \
-	curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
-	echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
-	patch -p1 --input=busybox-no-cbq.patch; \
-	rm busybox-no-cbq.patch
+	for patch in .patches/*.patch; do \
+		patch -p1 --input="$patch"; \
+	done; \
+	rm -rf .patches
+{{ ) else "" end -}}
 
 RUN set -eux; \
 	\

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ for dir; do
 			--load \
 			--tag "$base-builder" \
 			--file "$dir/Dockerfile.builder" \
-			"$dir"
+			. # context is "." so we can access the (shared) ".patches" directory
 
 		oci="$dir/$BASHBREW_ARCH"
 		rm -rf "$oci"

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -49,14 +49,15 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
-# https://github.com/docker-library/busybox/issues/198
-# https://bugs.busybox.net/show_bug.cgi?id=15931
-# https://bugs.debian.org/1071648
+# apply necessary/minimal patches (see /.patches/ in the top level of the repository)
+COPY \
+	/.patches/no-cbq.patch \
+	./.patches/
 RUN set -eux; \
-	curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
-	echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
-	patch -p1 --input=busybox-no-cbq.patch; \
-	rm busybox-no-cbq.patch
+	for patch in .patches/*.patch; do \
+		patch -p1 --input="$patch"; \
+	done; \
+	rm -rf .patches
 
 RUN set -eux; \
 	\

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -53,14 +53,15 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
-# https://github.com/docker-library/busybox/issues/198
-# https://bugs.busybox.net/show_bug.cgi?id=15931
-# https://bugs.debian.org/1071648
+# apply necessary/minimal patches (see /.patches/ in the top level of the repository)
+COPY \
+	/.patches/no-cbq.patch \
+	./.patches/
 RUN set -eux; \
-	curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
-	echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
-	patch -p1 --input=busybox-no-cbq.patch; \
-	rm busybox-no-cbq.patch
+	for patch in .patches/*.patch; do \
+		patch -p1 --input="$patch"; \
+	done; \
+	rm -rf .patches
 
 RUN set -eux; \
 	\

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -235,14 +235,15 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
-# https://github.com/docker-library/busybox/issues/198
-# https://bugs.busybox.net/show_bug.cgi?id=15931
-# https://bugs.debian.org/1071648
+# apply necessary/minimal patches (see /.patches/ in the top level of the repository)
+COPY \
+	/.patches/no-cbq.patch \
+	./.patches/
 RUN set -eux; \
-	curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
-	echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
-	patch -p1 --input=busybox-no-cbq.patch; \
-	rm busybox-no-cbq.patch
+	for patch in .patches/*.patch; do \
+		patch -p1 --input="$patch"; \
+	done; \
+	rm -rf .patches
 
 RUN set -eux; \
 	\

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -49,14 +49,16 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
-# https://github.com/docker-library/busybox/issues/198
-# https://bugs.busybox.net/show_bug.cgi?id=15931
-# https://bugs.debian.org/1071648
+# apply necessary/minimal patches (see /.patches/ in the top level of the repository)
+COPY \
+	/.patches/no-cbq.patch \
+	/.patches/sha1_process_block64_shaNI.patch \
+	./.patches/
 RUN set -eux; \
-	curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
-	echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
-	patch -p1 --input=busybox-no-cbq.patch; \
-	rm busybox-no-cbq.patch
+	for patch in .patches/*.patch; do \
+		patch -p1 --input="$patch"; \
+	done; \
+	rm -rf .patches
 
 RUN set -eux; \
 	\

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -53,14 +53,16 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
-# https://github.com/docker-library/busybox/issues/198
-# https://bugs.busybox.net/show_bug.cgi?id=15931
-# https://bugs.debian.org/1071648
+# apply necessary/minimal patches (see /.patches/ in the top level of the repository)
+COPY \
+	/.patches/no-cbq.patch \
+	/.patches/sha1_process_block64_shaNI.patch \
+	./.patches/
 RUN set -eux; \
-	curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
-	echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
-	patch -p1 --input=busybox-no-cbq.patch; \
-	rm busybox-no-cbq.patch
+	for patch in .patches/*.patch; do \
+		patch -p1 --input="$patch"; \
+	done; \
+	rm -rf .patches
 
 RUN set -eux; \
 	\

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -235,14 +235,16 @@ RUN set -eux; \
 
 WORKDIR /usr/src/busybox
 
-# https://github.com/docker-library/busybox/issues/198
-# https://bugs.busybox.net/show_bug.cgi?id=15931
-# https://bugs.debian.org/1071648
+# apply necessary/minimal patches (see /.patches/ in the top level of the repository)
+COPY \
+	/.patches/no-cbq.patch \
+	/.patches/sha1_process_block64_shaNI.patch \
+	./.patches/
 RUN set -eux; \
-	curl -fL -o busybox-no-cbq.patch 'https://bugs.busybox.net/attachment.cgi?id=9751'; \
-	echo '6671a12c48dbcefb653fc8403d1f103a1e2eba4a49b1ee9a9c27da8aa2db80d4 *busybox-no-cbq.patch' | sha256sum -c -; \
-	patch -p1 --input=busybox-no-cbq.patch; \
-	rm busybox-no-cbq.patch
+	for patch in .patches/*.patch; do \
+		patch -p1 --input="$patch"; \
+	done; \
+	rm -rf .patches
 
 RUN set -eux; \
 	\


### PR DESCRIPTION
This adds a directory for us to store patches we need to apply during build -- I've copied the "no CBQ" patch we've already been applying, and a new "sha1_process_block64_shaNI.patch" which applies a patch for our new non-x86 build failures (https://github.com/docker-library/busybox/pull/206#issuecomment-2384225988).

I've also added a README to the new patches directory to make it clear what types of patches are appropriate/acceptable (perhaps more accurately, why almost all patches are *not* acceptable).

This changes the build context for our rootfs builds to be the root of the repository so we don't have to muddy our template applying code with which patches to copy and can instead maintain that in the template itself (and skip the entire "patch applying" block of code when there are no patches to apply).