### PR TITLE
Remove some 1.35.x leftovers

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -290,10 +290,6 @@ RUN set -eux; \
 		CONFIG_FEATURE_UTMP \
 		CONFIG_FEATURE_WTMP \
 {{ ) else "" end -}}
-{{ if .version | startswith("1.35.") then ( -}}
-# disable SHA hardware acceleration (temporarily), as it fails with SIGILL on some of GitHub's common CI systems; https://bugs.busybox.net/show_bug.cgi?id=15236
-		CONFIG_SHA256_HWACCEL CONFIG_SHA1_HWACCEL \
-{{ ) else "" end -}}
 	'; \
 	\
 	make defconfig; \


### PR DESCRIPTION
Oops, this should've been part of 349fb1ced29eba72048b7dfd36c0207c9f0eb376 (https://github.com/docker-library/busybox/pull/206) 🙈