### PR TITLE
Use GitLab for all buildroot references

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -88,8 +88,8 @@ RUN set -eux; \
 		BR2_TOOLCHAIN_BUILDROOT_GLIBC \
 	'; \
 	\
-# buildroot arches: https://git.busybox.net/buildroot/tree/arch
-# buildroot+uclibc arches: https://git.busybox.net/buildroot/tree/package/uclibc/Config.in ("config BR2_PACKAGE_UCLIBC_ARCH_SUPPORTS")
+# buildroot arches: https://gitlab.com/buildroot.org/buildroot/-/tree/HEAD/arch
+# buildroot+uclibc arches: https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/package/uclibc/Config.in ("config BR2_PACKAGE_UCLIBC_ARCH_SUPPORTS")
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 # explicitly target amd64 v1
@@ -112,7 +112,7 @@ RUN set -eux; \
 			\
 # https://wiki.debian.org/ArmEabiPort#Choice_of_minimum_CPU
 # https://github.com/free-electrons/toolchains-builder/blob/db259641eaf5bbcf13f4a3c5003e5436e806770c/configs/arch/armv5-eabi.config
-# https://git.busybox.net/buildroot/tree/arch/Config.in.arm
+# https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/arch/Config.in.arm
 # (Debian minimums at ARMv4, we minimum at ARMv5 instead)
 		armel) \
 			setConfs="$setConfs \
@@ -127,7 +127,7 @@ RUN set -eux; \
 # "Currently the Debian armhf port requires at least an ARMv7 CPU with Thumb-2 and VFP3D16."
 # https://wiki.debian.org/ArmHardFloatPort#Supported_devices
 # https://github.com/free-electrons/toolchains-builder/blob/db259641eaf5bbcf13f4a3c5003e5436e806770c/configs/arch/armv7-eabihf.config
-# https://git.busybox.net/buildroot/tree/arch/Config.in.arm
+# https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/arch/Config.in.arm
 		armhf) \
 			setConfs="$setConfs \
 				BR2_arm=y \
@@ -415,7 +415,7 @@ RUN set -eux; \
 	; do \
 		dir="$(dirname "$file")"; \
 		mkdir -p "../buildroot/$dir"; \
-		curl -fL -o "../buildroot/$file" "https://git.busybox.net/buildroot/plain/$file?id=$buildrootVersion"; \
+		curl -fL -o "../buildroot/$file" "https://gitlab.com/buildroot.org/buildroot/-/raw/$buildrootVersion/$file"; \
 		[ -s "../buildroot/$file" ]; \
 	done; \
 	\
@@ -431,7 +431,7 @@ RUN set -eux; \
 	grep -E '^root::' rootfs/etc/shadow; \
 	sed -ri -e 's/^root::/root:*:/' rootfs/etc/shadow; \
 	grep -E '^root:[*]:' rootfs/etc/shadow; \
-# set expected permissions, etc too (https://git.busybox.net/buildroot/tree/system/device_table.txt)
+# set expected permissions, etc too (https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/system/device_table.txt)
 	awk ' \
 		!/^#/ { \
 			if ($2 != "d" && $2 != "f") { \

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -166,7 +166,7 @@ RUN set -eux; \
 	; do \
 		dir="$(dirname "$file")"; \
 		mkdir -p "../buildroot/$dir"; \
-		curl -fL -o "../buildroot/$file" "https://git.busybox.net/buildroot/plain/$file?id=$buildrootVersion"; \
+		curl -fL -o "../buildroot/$file" "https://gitlab.com/buildroot.org/buildroot/-/raw/$buildrootVersion/$file"; \
 		[ -s "../buildroot/$file" ]; \
 	done; \
 	\
@@ -181,7 +181,7 @@ RUN set -eux; \
 	grep -E '^root::' rootfs/etc/shadow; \
 	sed -ri -e 's/^root::/root:*:/' rootfs/etc/shadow; \
 	grep -E '^root:[*]:' rootfs/etc/shadow; \
-# set expected permissions, etc too (https://git.busybox.net/buildroot/tree/system/device_table.txt)
+# set expected permissions, etc too (https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/system/device_table.txt)
 	awk ' \
 		!/^#/ { \
 			if ($2 != "d" && $2 != "f") { \

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -149,7 +149,7 @@ RUN set -eux; \
 	; do \
 		dir="$(dirname "$file")"; \
 		mkdir -p "../buildroot/$dir"; \
-		curl -fL -o "../buildroot/$file" "https://git.busybox.net/buildroot/plain/$file?id=$buildrootVersion"; \
+		curl -fL -o "../buildroot/$file" "https://gitlab.com/buildroot.org/buildroot/-/raw/$buildrootVersion/$file"; \
 		[ -s "../buildroot/$file" ]; \
 	done; \
 	\
@@ -164,7 +164,7 @@ RUN set -eux; \
 	grep -E '^root::' rootfs/etc/shadow; \
 	sed -ri -e 's/^root::/root:*:/' rootfs/etc/shadow; \
 	grep -E '^root:[*]:' rootfs/etc/shadow; \
-# set expected permissions, etc too (https://git.busybox.net/buildroot/tree/system/device_table.txt)
+# set expected permissions, etc too (https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/system/device_table.txt)
 	awk ' \
 		!/^#/ { \
 			if ($2 != "d" && $2 != "f") { \

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -73,8 +73,8 @@ RUN set -eux; \
 		BR2_TOOLCHAIN_BUILDROOT_GLIBC \
 	'; \
 	\
-# buildroot arches: https://git.busybox.net/buildroot/tree/arch
-# buildroot+uclibc arches: https://git.busybox.net/buildroot/tree/package/uclibc/Config.in ("config BR2_PACKAGE_UCLIBC_ARCH_SUPPORTS")
+# buildroot arches: https://gitlab.com/buildroot.org/buildroot/-/tree/HEAD/arch
+# buildroot+uclibc arches: https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/package/uclibc/Config.in ("config BR2_PACKAGE_UCLIBC_ARCH_SUPPORTS")
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 # explicitly target amd64 v1
@@ -97,7 +97,7 @@ RUN set -eux; \
 			\
 # https://wiki.debian.org/ArmEabiPort#Choice_of_minimum_CPU
 # https://github.com/free-electrons/toolchains-builder/blob/db259641eaf5bbcf13f4a3c5003e5436e806770c/configs/arch/armv5-eabi.config
-# https://git.busybox.net/buildroot/tree/arch/Config.in.arm
+# https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/arch/Config.in.arm
 # (Debian minimums at ARMv4, we minimum at ARMv5 instead)
 		armel) \
 			setConfs="$setConfs \
@@ -112,7 +112,7 @@ RUN set -eux; \
 # "Currently the Debian armhf port requires at least an ARMv7 CPU with Thumb-2 and VFP3D16."
 # https://wiki.debian.org/ArmHardFloatPort#Supported_devices
 # https://github.com/free-electrons/toolchains-builder/blob/db259641eaf5bbcf13f4a3c5003e5436e806770c/configs/arch/armv7-eabihf.config
-# https://git.busybox.net/buildroot/tree/arch/Config.in.arm
+# https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/arch/Config.in.arm
 		armhf) \
 			setConfs="$setConfs \
 				BR2_arm=y \
@@ -323,7 +323,7 @@ RUN set -eux; \
 	grep -E '^root::' rootfs/etc/shadow; \
 	sed -ri -e 's/^root::/root:*:/' rootfs/etc/shadow; \
 	grep -E '^root:[*]:' rootfs/etc/shadow; \
-# set expected permissions, etc too (https://git.busybox.net/buildroot/tree/system/device_table.txt)
+# set expected permissions, etc too (https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/system/device_table.txt)
 	awk ' \
 		!/^#/ { \
 			if ($2 != "d" && $2 != "f") { \

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -167,7 +167,7 @@ RUN set -eux; \
 	; do \
 		dir="$(dirname "$file")"; \
 		mkdir -p "../buildroot/$dir"; \
-		curl -fL -o "../buildroot/$file" "https://git.busybox.net/buildroot/plain/$file?id=$buildrootVersion"; \
+		curl -fL -o "../buildroot/$file" "https://gitlab.com/buildroot.org/buildroot/-/raw/$buildrootVersion/$file"; \
 		[ -s "../buildroot/$file" ]; \
 	done; \
 	\
@@ -182,7 +182,7 @@ RUN set -eux; \
 	grep -E '^root::' rootfs/etc/shadow; \
 	sed -ri -e 's/^root::/root:*:/' rootfs/etc/shadow; \
 	grep -E '^root:[*]:' rootfs/etc/shadow; \
-# set expected permissions, etc too (https://git.busybox.net/buildroot/tree/system/device_table.txt)
+# set expected permissions, etc too (https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/system/device_table.txt)
 	awk ' \
 		!/^#/ { \
 			if ($2 != "d" && $2 != "f") { \

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -150,7 +150,7 @@ RUN set -eux; \
 	; do \
 		dir="$(dirname "$file")"; \
 		mkdir -p "../buildroot/$dir"; \
-		curl -fL -o "../buildroot/$file" "https://git.busybox.net/buildroot/plain/$file?id=$buildrootVersion"; \
+		curl -fL -o "../buildroot/$file" "https://gitlab.com/buildroot.org/buildroot/-/raw/$buildrootVersion/$file"; \
 		[ -s "../buildroot/$file" ]; \
 	done; \
 	\
@@ -165,7 +165,7 @@ RUN set -eux; \
 	grep -E '^root::' rootfs/etc/shadow; \
 	sed -ri -e 's/^root::/root:*:/' rootfs/etc/shadow; \
 	grep -E '^root:[*]:' rootfs/etc/shadow; \
-# set expected permissions, etc too (https://git.busybox.net/buildroot/tree/system/device_table.txt)
+# set expected permissions, etc too (https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/system/device_table.txt)
 	awk ' \
 		!/^#/ { \
 			if ($2 != "d" && $2 != "f") { \

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -73,8 +73,8 @@ RUN set -eux; \
 		BR2_TOOLCHAIN_BUILDROOT_GLIBC \
 	'; \
 	\
-# buildroot arches: https://git.busybox.net/buildroot/tree/arch
-# buildroot+uclibc arches: https://git.busybox.net/buildroot/tree/package/uclibc/Config.in ("config BR2_PACKAGE_UCLIBC_ARCH_SUPPORTS")
+# buildroot arches: https://gitlab.com/buildroot.org/buildroot/-/tree/HEAD/arch
+# buildroot+uclibc arches: https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/package/uclibc/Config.in ("config BR2_PACKAGE_UCLIBC_ARCH_SUPPORTS")
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
 # explicitly target amd64 v1
@@ -97,7 +97,7 @@ RUN set -eux; \
 			\
 # https://wiki.debian.org/ArmEabiPort#Choice_of_minimum_CPU
 # https://github.com/free-electrons/toolchains-builder/blob/db259641eaf5bbcf13f4a3c5003e5436e806770c/configs/arch/armv5-eabi.config
-# https://git.busybox.net/buildroot/tree/arch/Config.in.arm
+# https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/arch/Config.in.arm
 # (Debian minimums at ARMv4, we minimum at ARMv5 instead)
 		armel) \
 			setConfs="$setConfs \
@@ -112,7 +112,7 @@ RUN set -eux; \
 # "Currently the Debian armhf port requires at least an ARMv7 CPU with Thumb-2 and VFP3D16."
 # https://wiki.debian.org/ArmHardFloatPort#Supported_devices
 # https://github.com/free-electrons/toolchains-builder/blob/db259641eaf5bbcf13f4a3c5003e5436e806770c/configs/arch/armv7-eabihf.config
-# https://git.busybox.net/buildroot/tree/arch/Config.in.arm
+# https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/arch/Config.in.arm
 		armhf) \
 			setConfs="$setConfs \
 				BR2_arm=y \
@@ -324,7 +324,7 @@ RUN set -eux; \
 	grep -E '^root::' rootfs/etc/shadow; \
 	sed -ri -e 's/^root::/root:*:/' rootfs/etc/shadow; \
 	grep -E '^root:[*]:' rootfs/etc/shadow; \
-# set expected permissions, etc too (https://git.busybox.net/buildroot/tree/system/device_table.txt)
+# set expected permissions, etc too (https://gitlab.com/buildroot.org/buildroot/-/blob/HEAD/system/device_table.txt)
 	awk ' \
 		!/^#/ { \
 			if ($2 != "d" && $2 != "f") { \

--- a/versions.sh
+++ b/versions.sh
@@ -41,7 +41,7 @@ busyboxVersions="$(
 # ]
 
 buildrootVersion="$(
-	git ls-remote --tags https://git.busybox.net/buildroot \
+	git ls-remote --tags https://gitlab.com/buildroot.org/buildroot.git \
 		| cut -d/ -f3 \
 		| cut -d^ -f1 \
 		| grep -E '^[0-9]+' \


### PR DESCRIPTION
See https://git.busybox.net/buildroot/commit/?id=366d403bedd83d1e884b6c7c60a8a4ff497a458a (or rather, https://gitlab.com/buildroot.org/buildroot/-/commit/366d403bedd83d1e884b6c7c60a8a4ff497a458a -- or, if you prefer, the GitHub mirror at https://github.com/buildroot/buildroot/commit/366d403bedd83d1e884b6c7c60a8a4ff497a458a :joy:)