### PR TITLE
Fix reproducibility of non-uclibc i386 builds

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -15,6 +15,8 @@ RUN set -eux; \
 		tzdata \
 # busybox's tar ironically does not maintain mtime of directories correctly (which we need for SOURCE_DATE_EPOCH / reproducibility)
 		tar \
+# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
+		dpkg-dev dpkg \
 	;
 {{ ) else ( -}}
 FROM debian:bookworm-slim
@@ -28,6 +30,8 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
+# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
+		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 {{ ) end -}}
@@ -340,10 +344,15 @@ RUN set -eux; \
 
 RUN set -eux; \
 	nproc="$(nproc)"; \
+# https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
 {{ if env.variant == "uclibc" then ( -}}
 	CROSS_COMPILE="$(basename /usr/src/buildroot/output/host/usr/*-buildroot-linux-uclibc*)"; \
 	export CROSS_COMPILE="$CROSS_COMPILE-"; \
-{{ ) else "" end -}}
+{{ ) else ( -}}
+# we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
+	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+	export ARCH; \
+{{ ) end -}}
 	make -j "$nproc" busybox; \
 	./busybox --help; \
 	mkdir -p rootfs/bin; \

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -15,6 +15,8 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
+# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
+		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -110,6 +112,10 @@ RUN set -eux; \
 
 RUN set -eux; \
 	nproc="$(nproc)"; \
+# https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
+# we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
+	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+	export ARCH; \
 	make -j "$nproc" busybox; \
 	./busybox --help; \
 	mkdir -p rootfs/bin; \

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -20,6 +20,8 @@ RUN set -eux; \
 		tzdata \
 # busybox's tar ironically does not maintain mtime of directories correctly (which we need for SOURCE_DATE_EPOCH / reproducibility)
 		tar \
+# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
+		dpkg-dev dpkg \
 	;
 
 # pub   1024D/ACC9965B 2006-12-12
@@ -120,6 +122,10 @@ RUN set -eux; \
 
 RUN set -eux; \
 	nproc="$(nproc)"; \
+# https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
+# we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
+	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+	export ARCH; \
 	make -j "$nproc" busybox; \
 	./busybox --help; \
 	mkdir -p rootfs/bin; \

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -15,6 +15,8 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
+# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
+		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -296,6 +298,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 	nproc="$(nproc)"; \
+# https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
 	CROSS_COMPILE="$(basename /usr/src/buildroot/output/host/usr/*-buildroot-linux-uclibc*)"; \
 	export CROSS_COMPILE="$CROSS_COMPILE-"; \
 	make -j "$nproc" busybox; \

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -15,6 +15,8 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
+# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
+		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -111,6 +113,10 @@ RUN set -eux; \
 
 RUN set -eux; \
 	nproc="$(nproc)"; \
+# https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
+# we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
+	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+	export ARCH; \
 	make -j "$nproc" busybox; \
 	./busybox --help; \
 	mkdir -p rootfs/bin; \

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -20,6 +20,8 @@ RUN set -eux; \
 		tzdata \
 # busybox's tar ironically does not maintain mtime of directories correctly (which we need for SOURCE_DATE_EPOCH / reproducibility)
 		tar \
+# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
+		dpkg-dev dpkg \
 	;
 
 # pub   1024D/ACC9965B 2006-12-12
@@ -121,6 +123,10 @@ RUN set -eux; \
 
 RUN set -eux; \
 	nproc="$(nproc)"; \
+# https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
+# we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
+	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+	export ARCH; \
 	make -j "$nproc" busybox; \
 	./busybox --help; \
 	mkdir -p rootfs/bin; \

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -15,6 +15,8 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
+# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
+		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -297,6 +299,7 @@ RUN set -eux; \
 
 RUN set -eux; \
 	nproc="$(nproc)"; \
+# https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
 	CROSS_COMPILE="$(basename /usr/src/buildroot/output/host/usr/*-buildroot-linux-uclibc*)"; \
 	export CROSS_COMPILE="$CROSS_COMPILE-"; \
 	make -j "$nproc" busybox; \


### PR DESCRIPTION
Without this fix, if we try to build i386 on an amd64 machine without the linux32 "personality" applied, it uses `uname -m` and gets a slightly different result due to the lack of https://git.busybox.net/busybox/tree/arch/i386/Makefile?h=1_37_stable#n7 (adding `-march` and `-mtune` values to builds).

If we set `ARCH` appropriately during build, that file gets sourced and our builds include the appropriate values.

This does *not* affect uclibc builds because they set `CROSS_COMPILE`, which overrides the value of `(SUB)ARCH` (although it would be valid to set both in all cases, to be explicit, I just don't think that's necessary).