### PR TITLE
Fix i386 again, but correctly

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -15,8 +15,6 @@ RUN set -eux; \
 		tzdata \
 # busybox's tar ironically does not maintain mtime of directories correctly (which we need for SOURCE_DATE_EPOCH / reproducibility)
 		tar \
-# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
-		dpkg-dev dpkg \
 	;
 {{ ) else ( -}}
 FROM debian:bookworm-slim
@@ -30,8 +28,6 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
-# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
-		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 {{ ) end -}}
@@ -350,7 +346,20 @@ RUN set -eux; \
 	export CROSS_COMPILE="$CROSS_COMPILE-"; \
 {{ ) else ( -}}
 # we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
-	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+# see https://git.busybox.net/busybox/tree/arch?h=1_37_stable#n145 for the only important values this *has* to match (everything else is best-effort, and needs to match the munging in https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n185)
+	distroArch="$({{ if env.variant == "musl" then "apk --print-arch" else "dpkg --print-architecture" end }})"; \
+	case "$distroArch" in \
+		amd64 | x86_64)        ARCH='x86_64'  ;; \
+		arm64 | aarch64)       ARCH='aarch64' ;; \
+		armhf | armel | armv*) ARCH='arm'     ;; \
+		i386  | x86)           ARCH='i386'    ;; \
+		mips*)                 ARCH='mips'    ;; \
+		ppc*)                  ARCH='powerpc' ;; \
+		riscv64)               ARCH='riscv64' ;; \
+		s390x)                 ARCH='s390'    ;; \
+		*) echo >&2 "error: unknown architecture: '$distroArch'"; exit 1 ;; \
+	esac; \
+	[ -n "$ARCH" ]; \
 	export ARCH; \
 {{ ) end -}}
 	make -j "$nproc" busybox; \

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -15,8 +15,6 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
-# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
-		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -114,7 +112,20 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 # https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
 # we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
-	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+# see https://git.busybox.net/busybox/tree/arch?h=1_37_stable#n145 for the only important values this *has* to match (everything else is best-effort, and needs to match the munging in https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n185)
+	distroArch="$(dpkg --print-architecture)"; \
+	case "$distroArch" in \
+		amd64 | x86_64)        ARCH='x86_64'  ;; \
+		arm64 | aarch64)       ARCH='aarch64' ;; \
+		armhf | armel | armv*) ARCH='arm'     ;; \
+		i386  | x86)           ARCH='i386'    ;; \
+		mips*)                 ARCH='mips'    ;; \
+		ppc*)                  ARCH='powerpc' ;; \
+		riscv64)               ARCH='riscv64' ;; \
+		s390x)                 ARCH='s390'    ;; \
+		*) echo >&2 "error: unknown architecture: '$distroArch'"; exit 1 ;; \
+	esac; \
+	[ -n "$ARCH" ]; \
 	export ARCH; \
 	make -j "$nproc" busybox; \
 	./busybox --help; \

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -20,8 +20,6 @@ RUN set -eux; \
 		tzdata \
 # busybox's tar ironically does not maintain mtime of directories correctly (which we need for SOURCE_DATE_EPOCH / reproducibility)
 		tar \
-# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
-		dpkg-dev dpkg \
 	;
 
 # pub   1024D/ACC9965B 2006-12-12
@@ -124,7 +122,20 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 # https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
 # we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
-	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+# see https://git.busybox.net/busybox/tree/arch?h=1_37_stable#n145 for the only important values this *has* to match (everything else is best-effort, and needs to match the munging in https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n185)
+	distroArch="$(apk --print-arch)"; \
+	case "$distroArch" in \
+		amd64 | x86_64)        ARCH='x86_64'  ;; \
+		arm64 | aarch64)       ARCH='aarch64' ;; \
+		armhf | armel | armv*) ARCH='arm'     ;; \
+		i386  | x86)           ARCH='i386'    ;; \
+		mips*)                 ARCH='mips'    ;; \
+		ppc*)                  ARCH='powerpc' ;; \
+		riscv64)               ARCH='riscv64' ;; \
+		s390x)                 ARCH='s390'    ;; \
+		*) echo >&2 "error: unknown architecture: '$distroArch'"; exit 1 ;; \
+	esac; \
+	[ -n "$ARCH" ]; \
 	export ARCH; \
 	make -j "$nproc" busybox; \
 	./busybox --help; \

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -15,8 +15,6 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
-# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
-		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -20,8 +20,6 @@ RUN set -eux; \
 		tzdata \
 # busybox's tar ironically does not maintain mtime of directories correctly (which we need for SOURCE_DATE_EPOCH / reproducibility)
 		tar \
-# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
-		dpkg-dev dpkg \
 	;
 
 # pub   1024D/ACC9965B 2006-12-12
@@ -125,7 +123,20 @@ RUN set -eux; \
 	nproc="$(nproc)"; \
 # https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n145
 # we need to override SUBARCH explicitly (via ARCH) to avoid "uname -m" which gives the wrong answer for builds like i386 on an amd64 machine because kernel architecture != userspace architecture
-	ARCH="$(dpkg-architecture --query DEB_HOST_ARCH_CPU)"; \
+# see https://git.busybox.net/busybox/tree/arch?h=1_37_stable#n145 for the only important values this *has* to match (everything else is best-effort, and needs to match the munging in https://git.busybox.net/busybox/tree/Makefile?h=1_37_stable#n185)
+	distroArch="$(apk --print-arch)"; \
+	case "$distroArch" in \
+		amd64 | x86_64)        ARCH='x86_64'  ;; \
+		arm64 | aarch64)       ARCH='aarch64' ;; \
+		armhf | armel | armv*) ARCH='arm'     ;; \
+		i386  | x86)           ARCH='i386'    ;; \
+		mips*)                 ARCH='mips'    ;; \
+		ppc*)                  ARCH='powerpc' ;; \
+		riscv64)               ARCH='riscv64' ;; \
+		s390x)                 ARCH='s390'    ;; \
+		*) echo >&2 "error: unknown architecture: '$distroArch'"; exit 1 ;; \
+	esac; \
+	[ -n "$ARCH" ]; \
 	export ARCH; \
 	make -j "$nproc" busybox; \
 	./busybox --help; \

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -15,8 +15,6 @@ RUN set -eux; \
 		gnupg \
 		make \
 		patch \
-# we use dpkg-architecture to pass a sane (userspace) "ARCH" to busybox's Makefile (see below)
-		dpkg-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I moved too fast in https://github.com/docker-library/busybox/pull/216 and forgot to re-test amd64, which was ironically broken by my i386 fix, so now we do the full "distro arch to 'busybox arch'" conversion for the set of arches we support (which isn't *that* big).