### PR TITLE
Show curl errors

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -78,7 +78,7 @@ _tags() {
 
 _spider() {
 	local code
-	code="$(curl --head --silent --location -o /dev/null --write-out '%{http_code}' "$@")"
+	code="$(curl --head --silent --show-error --location --output /dev/null --write-out '%{http_code}' "$@")"
 	case "$code" in
 		200) return 0 ;;
 		404) return 1 ;;


### PR DESCRIPTION
>error: unexpected status code 000 while fetching: ...

The `update.sh` job has been running into errors fairly consistently for the past few days and this should show what that error is. It'll probably just show the same error that we are seeing in other jobs: `curl: (6) Could not resolve host: github.com`.