### PR TITLE
Enable CONFIG_FEATURE_EDITING_VI (set -o vi)

### DIFF
--- a/Dockerfile-builder.template
+++ b/Dockerfile-builder.template
@@ -310,6 +310,9 @@ RUN set -eux; \
 # https://git.busybox.net/busybox/tree/miscutils/inotifyd.c?id=6937487be73cd4563b876413277a295a5fe2f32c#n31
 # "default n  # doesn't build on Knoppix 5" 😅😂
 		CONFIG_INOTIFYD=y \
+		\
+# vi-style line editing ("set -o vi")
+		CONFIG_FEATURE_EDITING_VI=y \
 	'; \
 	\
 	unsetConfs=' \

--- a/latest-1/glibc/Dockerfile.builder
+++ b/latest-1/glibc/Dockerfile.builder
@@ -78,6 +78,9 @@ RUN set -eux; \
 # https://git.busybox.net/busybox/tree/miscutils/inotifyd.c?id=6937487be73cd4563b876413277a295a5fe2f32c#n31
 # "default n  # doesn't build on Knoppix 5" 😅😂
 		CONFIG_INOTIFYD=y \
+		\
+# vi-style line editing ("set -o vi")
+		CONFIG_FEATURE_EDITING_VI=y \
 	'; \
 	\
 	unsetConfs=' \

--- a/latest-1/musl/Dockerfile.builder
+++ b/latest-1/musl/Dockerfile.builder
@@ -84,6 +84,9 @@ RUN set -eux; \
 # https://git.busybox.net/busybox/tree/miscutils/inotifyd.c?id=6937487be73cd4563b876413277a295a5fe2f32c#n31
 # "default n  # doesn't build on Knoppix 5" 😅😂
 		CONFIG_INOTIFYD=y \
+		\
+# vi-style line editing ("set -o vi")
+		CONFIG_FEATURE_EDITING_VI=y \
 	'; \
 	\
 	unsetConfs=' \

--- a/latest-1/uclibc/Dockerfile.builder
+++ b/latest-1/uclibc/Dockerfile.builder
@@ -264,6 +264,9 @@ RUN set -eux; \
 # https://git.busybox.net/busybox/tree/miscutils/inotifyd.c?id=6937487be73cd4563b876413277a295a5fe2f32c#n31
 # "default n  # doesn't build on Knoppix 5" 😅😂
 		CONFIG_INOTIFYD=y \
+		\
+# vi-style line editing ("set -o vi")
+		CONFIG_FEATURE_EDITING_VI=y \
 	'; \
 	\
 	unsetConfs=' \

--- a/latest/glibc/Dockerfile.builder
+++ b/latest/glibc/Dockerfile.builder
@@ -77,6 +77,9 @@ RUN set -eux; \
 # https://git.busybox.net/busybox/tree/miscutils/inotifyd.c?id=6937487be73cd4563b876413277a295a5fe2f32c#n31
 # "default n  # doesn't build on Knoppix 5" 😅😂
 		CONFIG_INOTIFYD=y \
+		\
+# vi-style line editing ("set -o vi")
+		CONFIG_FEATURE_EDITING_VI=y \
 	'; \
 	\
 	unsetConfs=' \

--- a/latest/musl/Dockerfile.builder
+++ b/latest/musl/Dockerfile.builder
@@ -83,6 +83,9 @@ RUN set -eux; \
 # https://git.busybox.net/busybox/tree/miscutils/inotifyd.c?id=6937487be73cd4563b876413277a295a5fe2f32c#n31
 # "default n  # doesn't build on Knoppix 5" 😅😂
 		CONFIG_INOTIFYD=y \
+		\
+# vi-style line editing ("set -o vi")
+		CONFIG_FEATURE_EDITING_VI=y \
 	'; \
 	\
 	unsetConfs=' \

--- a/latest/uclibc/Dockerfile.builder
+++ b/latest/uclibc/Dockerfile.builder
@@ -263,6 +263,9 @@ RUN set -eux; \
 # https://git.busybox.net/busybox/tree/miscutils/inotifyd.c?id=6937487be73cd4563b876413277a295a5fe2f32c#n31
 # "default n  # doesn't build on Knoppix 5" 😅😂
 		CONFIG_INOTIFYD=y \
+		\
+# vi-style line editing ("set -o vi")
+		CONFIG_FEATURE_EDITING_VI=y \
 	'; \
 	\
 	unsetConfs=' \


### PR DESCRIPTION
The default is not to include vi editing but it is commonly included in distributions (e.g. Alpine) and is a big quality of life improvement for those used to vi keys. On my build (amd64) size(1) grows by +2k but the overall busybox executable size is unchanged due to being absorbed in padding.